### PR TITLE
Add example of KlongPy array shape difference

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ KlongPy is effectively a superset of the Klong language, but has some key differ
 * Infinite precision: The main difference in this implementation of Klong is the lack of infinite precision.  By using NumPy we are restricted to doubles.
 * Python integration: Most notably, the ".py" command allows direct import of Python modules into the current Klong context.
 * KlongPy aims to be more "batteries included" approach to modules and contains additional features such as IPC, Web service, Websockets, etc.
+* For array operations, KlongPy matches the shape of array arguments differently. Compare the results of an expression like `[1 2]+[[3 4][5 6]]` which in Klong produces `[[4 5] [7 8]]` but in KlongPy produces `[[4 6] [6 8]]`.
 
 # Related
 


### PR DESCRIPTION
Thanks for an incredible open source project!

This commit adds a short, high-level explanation with an inline code example of how Klong and KlongPy differ when lining up array shapes for operations like `+`.

I discovered this difference by working through Nils' _An Introduction to Array Programming in Klong_ using KlongPy.