### PR TITLE
Fix module import filter

### DIFF
--- a/klongpy/sys_fn.py
+++ b/klongpy/sys_fn.py
@@ -405,7 +405,7 @@ def _import_module(klong, x, from_set=None):
             module = import_module_from_sys(x)
 
         export_items = module.__dict__.get("klongpy_exports") or module.__dict__
-        ffn = lambda p: p[0] in from_set if from_set is not None else lambda p: not p[0].startswith("__")
+        ffn = (lambda p: p[0] in from_set) if from_set is not None else (lambda p: not p[0].startswith("__"))
 
         ctx = klong._context.pop()
         try:


### PR DESCRIPTION
## Summary
- fix logic for filtering imported names in module loader

## Testing
- `python3 -m py_compile klongpy/sys_fn.py`
- `python3 -m unittest tests.test_util` *(fails: ModuleNotFoundError: No module named 'numpy')*