### PR TITLE
Fix eval_monad_list return

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Repo guidelines
+
+To run the test suite, first install dependencies:
+
+```
+pip3 install ".[full]"
+```
+
+Then run:
+
+```
+python3 -m unittest
+```
+

--- a/klongpy/monads.py
+++ b/klongpy/monads.py
@@ -218,7 +218,7 @@ def eval_monad_list(a):
     if isinstance(a, KGChar):
         return str(a)
     if isinstance(a, KGSym):
-        np.asarray([a],dtype=object) # np interpets ':foo" as ':fo"
+        return np.asarray([a],dtype=object) # np interprets ':foo" as ':fo"
     return np.asarray([a])
 
 

--- a/tests/test_eval_monad_list.py
+++ b/tests/test_eval_monad_list.py
@@ -1,0 +1,34 @@
+import unittest
+import numpy as np
+
+from klongpy import KlongInterpreter
+from klongpy.core import KGSym
+from tests.utils import kg_equal
+
+
+class TestEvalMonadList(unittest.TestCase):
+
+    def setUp(self):
+        self.klong = KlongInterpreter()
+
+    def test_int(self):
+        r = self.klong(',1')
+        self.assertTrue(kg_equal(r, np.asarray([1])))
+
+    def test_symbol(self):
+        r = self.klong(',:foo')
+        self.assertTrue(r.dtype == object)
+        self.assertEqual(len(r), 1)
+        self.assertEqual(r[0], KGSym('foo'))
+
+    def test_string(self):
+        r = self.klong(',"xyz"')
+        self.assertTrue(kg_equal(r, np.asarray(['xyz'], dtype=object)))
+
+    def test_list(self):
+        r = self.klong(',[1]')
+        self.assertTrue(kg_equal(r, np.asarray([[1]], dtype=object)))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- document local test procedure in `AGENTS.md`
- test packaging via `eval_monad_list` with interpreter

## Testing
- `pip3 install ".[full]"` *(fails: Could not install build dependencies)*
- `python3 -m unittest` *(fails: `ModuleNotFoundError: No module named 'numpy'`)*