### PR TITLE
Add Terraform deployment for ticker plant

### DIFF
--- a/examples/deploy/terraform/tickerplant/README.md
+++ b/examples/deploy/terraform/tickerplant/README.md
@@ -1,0 +1,14 @@
+# Ticker Plant Terraform Deployment
+
+This Terraform module deploys the pub-sub ticker plant example `srv_pubsub.kg` to Kubernetes. The script is stored in a `ConfigMap` and executed using the `klongpy-app:latest` image from the Docker example.
+
+## Usage
+
+Ensure your Kubernetes context is configured and the `klongpy-app:latest` image is accessible by the cluster. Then run:
+
+```bash
+terraform init
+terraform apply
+```
+
+The deployment creates the `klongpy` namespace, a `Deployment` running the ticker plant, and a `Service` exposing port `8888`.

--- a/examples/deploy/terraform/tickerplant/main.tf
+++ b/examples/deploy/terraform/tickerplant/main.tf
@@ -1,0 +1,112 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.28"
+    }
+  }
+}
+
+provider "kubernetes" {
+  config_path = var.kubeconfig
+}
+
+variable "kubeconfig" {
+  description = "Path to kubeconfig file"
+  type        = string
+  default     = "~/.kube/config"
+}
+
+resource "kubernetes_namespace" "klongpy" {
+  metadata {
+    name = "klongpy"
+  }
+}
+
+resource "kubernetes_config_map" "tickerplant_script" {
+  metadata {
+    name      = "tickerplant-script"
+    namespace = kubernetes_namespace.klongpy.metadata[0].name
+  }
+
+  data = {
+    "srv_pubsub.kg" = file("../../../ipc/srv_pubsub.kg")
+  }
+}
+
+resource "kubernetes_deployment" "tickerplant" {
+  metadata {
+    name      = "tickerplant"
+    namespace = kubernetes_namespace.klongpy.metadata[0].name
+    labels = {
+      app = "tickerplant"
+    }
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = {
+        app = "tickerplant"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "tickerplant"
+        }
+      }
+
+      spec {
+        container {
+          name  = "tickerplant"
+          image = "klongpy-app:latest"
+
+          env {
+            name  = "KG_FILE_PATH"
+            value = "/scripts/srv_pubsub.kg"
+          }
+
+          port {
+            container_port = 8888
+          }
+
+          volume_mount {
+            name       = "script-volume"
+            mount_path = "/scripts"
+          }
+        }
+
+        volume {
+          name = "script-volume"
+
+          config_map {
+            name = kubernetes_config_map.tickerplant_script.metadata[0].name
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service" "tickerplant" {
+  metadata {
+    name      = "tickerplant"
+    namespace = kubernetes_namespace.klongpy.metadata[0].name
+  }
+
+  spec {
+    selector = {
+      app = "tickerplant"
+    }
+
+    port {
+      port        = 8888
+      target_port = 8888
+    }
+
+    type = "ClusterIP"
+  }
+}


### PR DESCRIPTION
## Summary
- add example Terraform module for Kubernetes tickerplant deployment

## Testing
- `python3 -m unittest` *(fails: ModuleNotFoundError: No module named 'numpy')*