### PR TITLE
Improve docs with REPL guide

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,9 @@ KlongPy is a Python adaptation of the [Klong](https://t3x.org/klong) [array lang
 pip3 install "klongpy[full]"
 ```
 
+New users may want to read the [Quick Start](quick-start.md) guide and the
+[REPL Reference](repl.md) to get familiar with the interactive environment.
+
 # Overview
 
 KlongPy is both an Array Language runtime and a set of powerful tools for building high performance data analysis and distributed computing applications.  Some of the features include:
@@ -20,6 +23,7 @@ KlongPy is both an Array Language runtime and a set of powerful tools for buildi
 * [__Python Integration__](python_integration.md): Seamlessly compatible with Python and modules, allowing you to leverage existing Python libraries and frameworks.
 * [__Web server__](web_server.md): Includes a web server, making it easy to build sites backed by KlongPy capabilities.
 * [__Timers__](timer.md): Includes periodic timer facility to periodically perform tasks.
+* [__Operator Reference__](operators.md): Quick lookup for language operators.
 
 # Examples
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -38,7 +38,7 @@ crtl-d or ]q to quit
 ?>
 ```
 
-See [REPL Reference](http://127.0.0.1:8000/repl.md) for more information on commands and operations.
+See the [REPL Reference](repl.md) for more information on commands and operations.
 
 ## Next Steps
 

--- a/docs/repl.md
+++ b/docs/repl.md
@@ -1,0 +1,29 @@
+# REPL Reference
+
+KlongPy comes with an interactive Read Eval Print Loop (REPL) which is helpful for experimenting with the language.
+
+Launch the REPL using `kgpy` (installing `rlwrap` is recommended for command history and line editing):
+
+```bash
+$ rlwrap kgpy
+```
+
+Once running you can evaluate expressions directly:
+
+```kgpy
+?> 1+1
+2
+```
+
+Several system commands prefixed with `]` are available:
+
+| Command | Description |
+|---------|-------------|
+| `]h topic` | Show help text for an operator or topic. |
+| `]a topic` | Search help topics. |
+| `]i dir` | List `.kg` files in a directory. Defaults to `KLONGPATH`. |
+| `]l file` | Load and execute a Klong source file. |
+| `]T expr` | Time the evaluation of an expression. Use `]T:n` to repeat `n` times. |
+| `]q` | Exit the REPL. |
+
+Press `Ctrl-D` can also be used to quit.


### PR DESCRIPTION
## Summary
- add a REPL reference document
- link quick-start page to the new REPL doc
- add operator reference link and quick-start note in index

## Testing
- `pip3 install ".[full]"` *(fails: Could not install build dependencies)*
- `python3 -m unittest` *(fails: ModuleNotFoundError: No module named 'numpy')*