### PR TITLE
Add cointegration module and update streaming scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ KlongPy is both an Array Language runtime and a set of powerful tools for buildi
 * [__Python Integration__](docs/python_integration.md): Seamlessly compatible with Python and modules, allowing you to leverage existing Python libraries and frameworks.
 * [__Web server__](docs/web_server.md): Includes a web server, making it easy to build sites backed by KlongPy capabilities.
 * [__Timers__](docs/timer.md): Includes periodic timer facility to periodically perform tasks.
+* [__Cointegration__](docs/cointegration.md): Wrapper for Johansen cointegration from statsmodels.
 
 # KlongPy Examples
 

--- a/docs/cointegration.md
+++ b/docs/cointegration.md
@@ -1,0 +1,15 @@
+# Cointegration
+
+KlongPy includes a small wrapper around the Johansen cointegration test from the Python `statsmodels` package.
+
+Load the library and run the test on two price series:
+
+```kg
+.l("cointegration.kg")
+prices1::[100 101 99 102 98]
+prices2::[50 50.5 49 51 48]
+result::johansen([prices1;prices2];0;1)
+.p(result)
+```
+
+The function `johansen(data;det;k)` returns the object produced by `statsmodels.tsa.vector_ar.vecm.coint_johansen`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@ KlongPy is both an Array Language runtime and a set of powerful tools for buildi
 * [__Python Integration__](python_integration.md): Seamlessly compatible with Python and modules, allowing you to leverage existing Python libraries and frameworks.
 * [__Web server__](web_server.md): Includes a web server, making it easy to build sites backed by KlongPy capabilities.
 * [__Timers__](timer.md): Includes periodic timer facility to periodically perform tasks.
+* [__Cointegration__](cointegration.md): Wrapper for Johansen cointegration from statsmodels.
 
 # Examples
 

--- a/examples/stocks/alpaca/ws/feed.kg
+++ b/examples/stocks/alpaca/ws/feed.kg
@@ -37,6 +37,10 @@ updSubscription::{[v q];.d("subscribing: ");v::unionValues(x);v::psmsg(v);.p(v);
 clients:::{}
 rmclient::{x_clients}
 
+:" Store recent bars for delta sync "
+history:::{}
+recordData::{[sym d];sym::d?"S";history,sym,,(history?sym),,[d]}
+
 :" Handle server auth request "
 sendAuth::{.p("sending auth");.p(auth);x(auth)}
 handleUnknown::{.d("unhandled");.p(y)}
@@ -56,19 +60,25 @@ mkts::{[d ts];d::.pyc("parse_date";,x;:{});.pyc(d,,"timestamp";[];:{})}
 send::{.d("sending ");.d(k);.d(" to client ");.p(y);y(:update,,z)}
 match::{[ev k subscription];ev::x;k::y;subscription::z;all::ev,".*";:[subscription?all;1;:[subscription?k;1;0]]}
 broadcast::{[ev k data];ev::x;k::y;data::z;{:[match(ev;k;x@1);send(k;x@0;data);0]}'clients}
-handleData::{[ev sym k];.d("data: ");.p(y);ev::(y?"T");sym::(y?"S");y,"t",mkts(y?"t");k::ev,".",sym;broadcast(ev;k;y)}
+handleData::{[ev sym k];.d("data: ");.p(y);ev::(y?"T");sym::(y?"S");y,"t",mkts(y?"t");recordData(sym;y);k::ev,".",sym;broadcast(ev;k;y)}
 
 handleMsg::{:[(y?"T")="b";handleData(x;y);handleStatus(x;y)]}
 
 .ws.m::{[c];c::x;{handleMsg(c;x)}'y}
 
 wsuri:::[(#.os.argv);.os.argv@0;"wss://stream.data.alpaca.markets/v2/sip"]
-.d("connecting to ");.p(wsuri)
-wsc::.ws(wsuri)
+connect::{.d("connecting to ");.p(wsuri);wsc::.ws(wsuri);sendAuth(wsc)}
+reconnect::{wsc::.ws(wsuri);sendAuth(wsc)}
+checkConn::{:[.pyc("is_open";wsc;[]);1;reconnect()]}
+.timer("reconnect";30;checkConn)
+connect()
 
 :" Called by clients to subscribe to ticker updates "
 updClientSub::{clients,x,,(clients?x),,y;.d("clients: ");.p(clients)}
 subscribe::{.d("subscribing client: ");.p(.cli.h,,x);updClientSub(.cli.h;x);updSubscription(clients);x}
+
+:" Return bars after the given timestamp for delta sync "
+delta::{[sym ts data k];sym::x@0;ts::x@1;data::history?sym;k::"b.",sym;{:[(y?"t")>ts;send(k;.cli.h;y);1;0]}'data;0}
 
 :" Setup the IPC server and callbacks "
 .srv(8888)

--- a/examples/stocks/alpaca/ws/feed_consumer.kg
+++ b/examples/stocks/alpaca/ws/feed_consumer.kg
@@ -19,7 +19,7 @@ Sample bars data:
   "t": "2021-02-22T19:15:00Z" (converted to timestamp on server)
 }
 
-TODO: add delta sync against feed server
+Delta sync against feed server via `deltaSync`
 
 ****
 
@@ -55,7 +55,12 @@ timeStore::{[r];r::time(store);.d("store ms: ");.p(r)}
 .p("connecting to server on port 8888")
 cli::.cli(8888)
 
-cli(:subscribe,,["b.MSFT" "b.AAPL" "b.GOOG"])
+symbols::["b.MSFT" "b.AAPL" "b.GOOG"]
+cli(:subscribe,,symbols)
+lastTs::0
+deltaSync::{cli(:delta,,[x;lastTs])}
+syncAll::{deltaSync'x}
+syncAll(symbols)
 
 :" A basic bollinger band strategy "
 mean::{(+/x)%#x}
@@ -68,7 +73,7 @@ timeAnalyze::{time(analyze)}
 analyzeComplete::{.d("analyze ms: ");.p(x)}
 asyncAnalyze::.async(timeAnalyze;analyzeComplete)
 
-updateDb::{.insert(prices;x@cols)}
+updateDb::{lastTs::x?"t";.insert(prices;x@cols)}
 timeUpdateDb::{.d("insert: ");.d(x@cols);.d(" ");.d(time1(updateDb;x));.p(" ms")}
 
 :" Called by server when there is a subscription update."

--- a/examples/stocks/cointegration/pairs_trading_example.kg
+++ b/examples/stocks/cointegration/pairs_trading_example.kg
@@ -1,0 +1,9 @@
+.l("cointegration.kg")
+
+: "Example pairs trading signal using Johansen cointegration"
+
+prices1::[100 101 99 102 98 97 99 100 101 99]
+prices2::[50 50.5 49 51 48 47.5 49 49.5 50 48.5]
+
+result::johansen([prices1;prices2];0;1)
+.p(result)

--- a/klongpy/lib/cointegration.kg
+++ b/klongpy/lib/cointegration.kg
@@ -1,0 +1,6 @@
+:"Johansen cointegration test"
+
+.pyf("statsmodels.tsa.vector_ar.vecm";"coint_johansen")
+
+johansen::{[data det k];.pyc(coint_johansen;data;det;k)}
+


### PR DESCRIPTION
## Summary
- add cointegration wrapper library and doc page
- reference cointegration feature in README and docs index
- add cointegration example for pairs trading
- enhance Alpaca feed scripts with reconnect logic and delta sync hooks

## Testing
- `pip3 install -e .[full]` *(failed: Could not find a version that satisfies the requirement setuptools>=40.8.0)*
- `python3 -m unittest` *(failed to import modules: ModuleNotFoundError: No module named 'numpy')*