### PR TITLE
Add experimental kdb+ IPC support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ KlongPy is both an Array Language runtime and a set of powerful tools for buildi
 * [__Speed__](docs/performance.md): Designed for high-speed vectorized computing, enabling you to process large data sets quickly and efficiently on either CPU or GPU.
 * [__Fast Columnar Database__](docs/fast_columnar_database.md): Includes integration with [DuckDb](http://duckdb.org), a super fast in-process columnar store that can operate directly on NumPy arrays with zero-copy.
 * [__Inter-Process Communication (IPC)__](docs/ipc_capabilities.md): Includes built-in support for IPC, enabling easy communication between different processes and systems. Ticker plants and similar pipelines are easy to build.
+* **kdb+ Integration via qpython:** Experimental support for connecting to kdb+ processes using qpython.
 * [__Table and Key-Value Store__](docs/table_and_key_value_stores.md): Includes a simple file-backed key value store that can be used to store database tables or raw key/value pairs.
 * [__Python Integration__](docs/python_integration.md): Seamlessly compatible with Python and modules, allowing you to leverage existing Python libraries and frameworks.
 * [__Web server__](docs/web_server.md): Includes a web server, making it easy to build sites backed by KlongPy capabilities.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ KlongPy is both an Array Language runtime and a set of powerful tools for buildi
 * [__Speed__](performance.md): Designed for high-speed vectorized computing, enabling you to process large data sets quickly and efficiently on either CPU or GPU.
 * [__Fast Columnar Database__](fast_columnar_database.md): Includes integration with [DuckDb](http://duckdb.org), a super fast in-process columnar store that can operate directly on NumPy arrays with zero-copy.
 * [__Inter-Process Communication (IPC)__](ipc_capabilities.md): Includes built-in support for IPC, enabling easy communication between different processes and systems. Ticker plants and similar pipelines are easy to build.
+* **kdb+ Integration via qpython:** Experimental support for communicating with kdb+ processes.
 * [__Table and Key-Value Store__](table_and_key_value_stores.md): Includes a simple file-backed key value store that can be used to store database tables or raw key/value pairs.
 * [__Python Integration__](python_integration.md): Seamlessly compatible with Python and modules, allowing you to leverage existing Python libraries and frameworks.
 * [__Web server__](web_server.md): Includes a web server, making it easy to build sites backed by KlongPy capabilities.

--- a/klongpy/interpreter.py
+++ b/klongpy/interpreter.py
@@ -7,6 +7,7 @@ from .dyads import create_dyad_functions
 from .monads import create_monad_functions
 from .sys_fn import create_system_functions
 from .sys_fn_ipc import create_system_functions_ipc, create_system_var_ipc
+from .sys_fn_kdb import create_system_functions_kdb
 from .sys_fn_timer import create_system_functions_timer
 from .sys_var import *
 from .utils import ReadonlyDict
@@ -142,6 +143,7 @@ def create_system_contexts():
     sys_d = {}
     add_context_key_values(sys_d, create_system_functions())
     add_context_key_values(sys_d, create_system_functions_ipc())
+    add_context_key_values(sys_d, create_system_functions_kdb())
     add_context_key_values(sys_d, create_system_functions_timer())
     set_context_var(sys_d, KGSym('.e'), eval_sys_var_epsilon()) # TODO: support lambda
     set_context_var(sys_d, KGSym('.cin'), cin)

--- a/klongpy/sys_fn_kdb.py
+++ b/klongpy/sys_fn_kdb.py
@@ -1,0 +1,158 @@
+import sys
+import logging
+from .core import KGLambda, KGCall, KGSym, KGFn, KlongException, reserved_fn_args, reserved_fn_symbol_map
+
+try:
+    from qpython import qconnection
+except Exception:  # ImportError or other
+    qconnection = None
+
+class KdbConnection:
+    def __init__(self, host='localhost', port=5000, user=None, password=None):
+        if qconnection is None:
+            raise KlongException("qpython not installed")
+        self.conn = qconnection.QConnection(host=host, port=port, username=user, password=password)
+        self.conn.open()
+
+    def execute(self, query):
+        return self.conn(query)
+
+    def close(self):
+        if self.conn.is_connected():
+            self.conn.close()
+
+    def is_open(self):
+        return self.conn.is_connected()
+
+    def __str__(self):
+        return f"q[{self.conn.host}:{self.conn.port}]"
+
+class KdbFnProxy(KGLambda):
+    def __init__(self, connection, name, arity=1):
+        self.connection = connection
+        self.name = name
+        self.args = reserved_fn_args[:arity]
+
+    def __call__(self, _, ctx):
+        params = [ctx[reserved_fn_symbol_map[x]] for x in self.args]
+        args_str = ','.join(map(str, params))
+        qexp = f"{self.name} {args_str}" if args_str else self.name
+        return self.connection.execute(qexp)
+
+    def __str__(self):
+        return f"{str(self.connection)}:{self.name}:fn"
+
+class KdbDictHandle(dict):
+    def __init__(self, connection):
+        self.connection = connection
+
+    def __getitem__(self, x):
+        return self.get(x)
+
+    def __setitem__(self, x, y):
+        return self.set(x, y)
+
+    def __contains__(self, x):
+        try:
+            _ = self.get(x)
+            return True
+        except Exception:
+            return False
+
+    def get(self, x):
+        if isinstance(x, KGSym):
+            qexp = f"value {x}"
+            r = self.connection.execute(qexp)
+            if isinstance(r, qconnection.QFunction):
+                return KdbFnProxy(self.connection, str(x))
+            return r
+        else:
+            return self.connection.execute(x)
+
+    def set(self, x, y):
+        if isinstance(x, KGSym):
+            qexp = f"{x}::{y}"
+        else:
+            qexp = str(x)
+        self.connection.execute(qexp)
+        return self
+
+    def close(self):
+        self.connection.close()
+
+    def is_open(self):
+        return self.connection.is_open()
+
+    def __str__(self):
+        return f"{str(self.connection)}:dict"
+
+# evaluation functions
+
+def eval_sys_fn_qcli(klong, x):
+    """
+        .qcli(x)                                 [Create-KDB-client]
+
+        Create a kdb+ IPC client. "x" may be an integer interpreted as a port on localhost, or a string "<host>:<port>".
+        Returns a remote function handle which executes q expressions on the server.
+    """
+    x = x.a if isinstance(x, KGCall) else x
+    if isinstance(x, KdbConnection):
+        conn = x
+    elif isinstance(x, KdbDictHandle):
+        conn = x.connection
+    else:
+        addr = str(x)
+        parts = addr.split(":")
+        host = parts[0] if len(parts) > 1 else "localhost"
+        port = int(parts[0] if len(parts) == 1 else parts[1])
+        conn = KdbConnection(host=host, port=port)
+    return KdbFnProxy(conn, "")
+
+
+def eval_sys_fn_qclid(klong, x):
+    """
+        .qclid(x)                            [Create-KDB-dict-client]
+
+        Similar to .qcli but returns a dictionary style handle for remote access.
+    """
+    x = x.a if isinstance(x, KGCall) else x
+    if isinstance(x, KdbDictHandle):
+        return x
+    if isinstance(x, KdbConnection):
+        conn = x
+    else:
+        addr = str(x)
+        parts = addr.split(":")
+        host = parts[0] if len(parts) > 1 else "localhost"
+        port = int(parts[0] if len(parts) == 1 else parts[1])
+        conn = KdbConnection(host=host, port=port)
+    return KdbDictHandle(conn)
+
+
+def eval_sys_fn_qclic(x):
+    """
+        .qclic(x)                                 [Close-KDB-client]
+
+        Close a kdb+ IPC connection opened via .qcli or .qclid.
+    """
+    if isinstance(x, KGCall):
+        x = x.a
+    if isinstance(x, (KdbDictHandle, KdbConnection, KdbFnProxy)):
+        conn = x.connection if hasattr(x, 'connection') else x
+        if conn.is_open():
+            conn.close()
+            return 1
+    return 0
+
+
+def create_system_functions_kdb():
+    def _get_name(s):
+        i = s.index(".")
+        return s[i : i + s[i:].index("(")]
+
+    registry = {}
+    m = sys.modules[__name__]
+    for x in filter(lambda n: n.startswith("eval_sys_"), dir(m)):
+        fn = getattr(m, x)
+        registry[_get_name(fn.__doc__)] = fn
+    return registry

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ extra_requires = {
         'web': ["aiohttp==3.9.4"],
         'db': ["pandas==2.2.2","duckdb==1.0.0"],
         'ws': ["websockets==12.0"],
+        'kdb': ["qpython"],
     }
 
 # full feature set extras


### PR DESCRIPTION
## Summary
- add experimental qpython-based kdb+ IPC functions
- expose new kdb+ system functions in interpreter
- document kdb+ integration in README and docs index
- allow optional `qpython` extra in setup

## Testing
- `pip3 install ".[full]"` *(failed: Could not find a version that satisfies the requirement setuptools>=40.8.0)*
- `python3 -m unittest` *(failed: ModuleNotFoundError: No module named 'numpy')*