### PR TITLE
Add wildcard slice behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ KlongPy is a Python adaptation of the [Klong](https://t3x.org/klong) [array lang
 - **Vectorized Operations with NumPy:** At its core, KlongPy uses [NumPy](https://numpy.org/), an [Iverson Ghost](https://analyzethedatanotthedrivel.org/2018/03/31/NumPy-another-iverson-ghost/) descendant from APL, for high-efficiency array manipulations.
 - **CPU and GPU Backend Support:** Incorporating [CuPy](https://github.com/cupy/cupy), KlongPy extends its capabilities to operate on both CPU and GPU backends, ensuring versatile and powerful computing options.
 - **Seamless Integration with Python Ecosystem:** The combination of KlongPy's built-in features with Python's wide-ranging libraries enables developers to build complex applications effortlessly.
+- **NumPy-like Slicing:** Use an empty list (`[]`) as a wildcard when reshaping or indexing to mirror NumPy's slice behavior.
 
 ## KlongPy's Foundation and Applications
 

--- a/klongpy/dyads.py
+++ b/klongpy/dyads.py
@@ -450,6 +450,14 @@ def eval_dyad_index_in_depth(a, b):
                         {y+x*x}:@[2 3]  -->  7
 
     """
+    if is_list(b):
+        idx = []
+        for x in b:
+            if isinstance(x, list) and len(x) == 0:
+                idx.append(slice(None))
+            else:
+                idx.append(x)
+        b = idx
     return np.asarray(a)[tuple(b) if is_list(b) else b] if not is_empty(b) else b
 
 
@@ -801,6 +809,21 @@ def eval_dyad_reshape(a, b):
     b = str_to_chr_arr(b) if j else b
     if np.isarray(a):
         if np.isarray(b):
+            # allow one wildcard dimension specified as an empty list []
+            wc_idx = None
+            a_list = []
+            for idx, dim in enumerate(a):
+                if isinstance(dim, list) and len(dim) == 0:
+                    if wc_idx is not None:
+                        raise ValueError("multiple wildcard dimensions not supported")
+                    wc_idx = idx
+                    a_list.append(-1)
+                else:
+                    a_list.append(int(dim))
+            if wc_idx is not None:
+                prod_other = int(np.prod([d for d in a_list if d != -1]))
+                a_list[wc_idx] = b.size // prod_other if prod_other != 0 else b.size
+                a = np.asarray(a_list)
             y = np.where(a < 0)[0]
             if len(y) > 0:
                 a = np.copy(a)

--- a/tests/test_numpy_slice.py
+++ b/tests/test_numpy_slice.py
@@ -1,0 +1,13 @@
+import unittest
+from utils import eval_cmp
+from klongpy import KlongInterpreter
+
+class TestNumpySliceBehavior(unittest.TestCase):
+    def assert_eval_cmp(self, a, b, klong=None):
+        self.assertTrue(eval_cmp(a, b, klong=klong))
+
+    def test_reshape_wildcard(self):
+        self.assert_eval_cmp('[2 []]:^[1 2 3 4]', '[[1 2] [3 4]]')
+
+    def test_index_in_depth_wildcard(self):
+        self.assert_eval_cmp('[[1 2 3] [4 5 6]]:@[[] 1]', '[2 5]')


### PR DESCRIPTION
## Summary
- enable wildcard slice for reshaping and index-in-depth
- document wildcard slice capability
- test empty-list wildcard behaviour

## Testing
- `pip3 install ".[full]"` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*
- `python3 -m unittest` *(fails: ModuleNotFoundError: No module named 'numpy')*