### PR TITLE
Fix Format2 handling of lists

### DIFF
--- a/klongpy/dyads.py
+++ b/klongpy/dyads.py
@@ -401,9 +401,11 @@ def _e_dyad_format2(a, b):
     """
     Unravel the broadcasting of a and b and apply __e_dyad_format2
     """
+    if is_list(a) and is_list(b):
+        return kg_asarray([vec_fn2(x, y, _e_dyad_format2) for x, y in zip(to_list(a), to_list(b))])
     if np.isarray(a) and np.isarray(b):
-        return np.asarray([vec_fn2(x,y,_e_dyad_format2) for x,y in zip(a,b)])
-    return __e_dyad_format2(a,b)
+        return np.asarray([vec_fn2(x, y, _e_dyad_format2) for x, y in zip(a, b)])
+    return __e_dyad_format2(a, b)
 
 def eval_dyad_format2(a, b):
     """

--- a/klongpy/lib/help.kg
+++ b/klongpy/lib/help.kg
@@ -30,8 +30,8 @@ op.db::[
  [" a:$b" "Form"
   "b=string; convert 'b' to an object of the same form (type) as 'a'"]
  [" $a" "Format" "convert 'a' to a string representing the value of 'a'"]
- [" a$b" "Format2"
-  "a=real; Format 'b', pad with 'a' blanks or to align to x.y digits"]
+[" a$b" "Format2"
+ "a=real|list; when both operands are lists, apply pairwise. Format 'b', pad with 'a' blanks or to align to x.y digits"]
  [" >a" "Grade-Down"
   "a=vector; vector of indices of elements of 'a' in ascending order"]
  [" <a" "Grade-Up"

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -484,6 +484,7 @@ class TestCoreSuite(unittest.TestCase):
         self.assert_eval_cmp('5$1.23', '"1.23 "')
         self.assert_eval_cmp('5$-1.23', '"-1.23"')
         self.assert_eval_cmp('6$-1.23', '"-1.23 "')
+        self.assert_eval_cmp('[1]$[1]', '["1"]')
         self.assert_eval_cmp('(-10)$0', '"         0"')
         self.assert_eval_cmp('(-10)$123', '"       123"')
         self.assert_eval_cmp('(-10)$-123', '"      -123"')


### PR DESCRIPTION
## Summary
- support pairwise Format2 over lists and arrays
- clarify docstring entry for Format2
- test Format2 with array operands

## Testing
- `pip3 install ".[full]"` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*
- `python3 -m unittest`