### PR TITLE
Add reshape string regression tests

### DIFF
--- a/klongpy/dyads.py
+++ b/klongpy/dyads.py
@@ -181,7 +181,11 @@ def eval_dyad_at_index(klong, a, b):
         j = False
     else:
         r = a
-    return "".join(r) if j else r
+    if j:
+        if np.isarray(r) and r.ndim > 1:
+            return np.asarray(["".join(x) for x in r], dtype=object)
+        return "".join(r)
+    return r
 
 
 def eval_dyad_define(klong, n, v):
@@ -832,7 +836,11 @@ def eval_dyad_reshape(a, b):
                 r = np.concatenate((np.tile(b,ns), b[:a - b.shape[0]*ns[0]]))
         else:
             r = np.full((a,), b)
-    return "".join(r) if j else r
+    if j:
+        if np.isarray(r) and r.ndim > 1:
+            return np.asarray(["".join(x) for x in r], dtype=object)
+        return "".join(r)
+    return r
 
 
 def eval_dyad_rotate(a, b):

--- a/tests/test_reshape_strings.py
+++ b/tests/test_reshape_strings.py
@@ -1,0 +1,33 @@
+import unittest
+import numpy as np
+
+from klongpy import KlongInterpreter
+from tests.utils import kg_equal
+
+class TestReshapeStrings(unittest.TestCase):
+    def setUp(self):
+        self.klong = KlongInterpreter()
+
+    def test_reshape_string_len1(self):
+        r = self.klong('[2 2]:^"a"')
+        self.assertTrue(kg_equal(r, np.asarray(["aa", "aa"], dtype=object)))
+
+    def test_reshape_string_len2(self):
+        r = self.klong('[2 2]:^"ab"')
+        self.assertTrue(kg_equal(r, np.asarray(["ab", "ab"], dtype=object)))
+
+    def test_reshape_string_len3(self):
+        r = self.klong('[2 2]:^"abc"')
+        self.assertTrue(kg_equal(r, np.asarray(["ab", "ca"], dtype=object)))
+
+    def test_reshape_string_len4(self):
+        r = self.klong('[2 2]:^"abcd"')
+        self.assertTrue(kg_equal(r, np.asarray(["ab", "cd"], dtype=object)))
+
+    def test_reshape_string_larger_shape(self):
+        r = self.klong('[3 3]:^"abcd"')
+        self.assertTrue(kg_equal(r, np.asarray(["abc", "dab", "cda"], dtype=object)))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add new unit tests checking reshape on string inputs

## Testing
- `python3 -m unittest tests.test_reshape_strings`
- `python3 -m unittest`
