### PR TITLE
Expand numpy slice tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,22 @@ $ curl http://localhost:8888
 ['Hello, Klong World! ' 0 1 2 3 4 5 6 7 8 9]
 ```
 
+## 7. Expressive Array Slicing
+
+NumPy style slicing is supported via the empty list `[]` wildcard.  This makes reshaping
+or indexing multi-dimensional arrays concise and familiar.
+
+```kgpy
+?> [2 []]:^[1 2 3 4]  :" automatically infer second dimension"
+[[1 2]
+ [3 4]]
+?> m::[[1 2 3] [4 5 6]]
+[[1 2 3]
+ [4 5 6]]
+?> m@[[] 2] :" get all rows from column 2"
+[3 6]
+```
+
 ## Conclusion
 
 These examples are designed to illustrate the "batteries included" approach, ease of use and diverse applications of KlongPy, making it a versatile choice for various programming needs.

--- a/tests/test_numpy_slice.py
+++ b/tests/test_numpy_slice.py
@@ -11,3 +11,32 @@ class TestNumpySliceBehavior(unittest.TestCase):
 
     def test_index_in_depth_wildcard(self):
         self.assert_eval_cmp('[[1 2 3] [4 5 6]]:@[[] 1]', '[2 5]')
+
+    def test_reshape_wildcard_front(self):
+        """Wildcard as the first dimension"""
+        self.assert_eval_cmp('[[] 2]:^[1 2 3 4 5 6]', '[[1 2] [3 4] [5 6]]')
+
+    def test_index_row_wildcard(self):
+        """Select entire first row using wildcard"""
+        self.assert_eval_cmp('[[1 2 3] [4 5 6]]:@[0 []]', '[1 2 3]')
+
+    def test_index_column_wildcard(self):
+        """Select entire third column using wildcard"""
+        self.assert_eval_cmp('[[1 2 3] [4 5 6]]:@[[] 2]', '[3 6]')
+
+    def test_index_negative_row(self):
+        """Use negative index for last row"""
+        self.assert_eval_cmp('[[1 2 3] [4 5 6]]:@[-1 []]', '[4 5 6]')
+
+    def test_index_negative_column(self):
+        """Use negative index for last column"""
+        self.assert_eval_cmp('[[1 2 3] [4 5 6]]:@[[] -1]', '[3 6]')
+
+    def test_index_entire_matrix(self):
+        """Wildcard for all rows and columns"""
+        self.assert_eval_cmp('[[1 2 3] [4 5 6]]:@[[] []]', '[[1 2 3] [4 5 6]]')
+
+    def test_index_3d_wildcard(self):
+        """Indexing into 3D array with wildcard"""
+        expr = '[[[1 2] [3 4]] [[5 6] [7 8]]]:@[1 0 []]'
+        self.assert_eval_cmp(expr, '[5 6]')


### PR DESCRIPTION
## Summary
- broaden numpy slice test coverage with wildcard indices and negatives
- document expressive slicing in README

## Testing
- `python3 -m unittest tests.test_numpy_slice`
- `python3 -m unittest`