### PR TITLE
Clarify NumPy slice behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,13 +295,13 @@ NumPy style slicing is supported via the empty list `[]` wildcard.  This makes r
 or indexing multi-dimensional arrays concise and familiar.
 
 ```kgpy
-?> [2 []]:^[1 2 3 4]  :" automatically infer second dimension"
+?> [2 []]:^[1 2 3 4]  :" automatically infer second dimension"  # np.reshape([1,2,3,4], (2,-1))
 [[1 2]
  [3 4]]
-?> m::[[1 2 3] [4 5 6]]
+?> m::[[1 2 3] [4 5 6]]                                # m = np.array([[1,2,3],[4,5,6]])
 [[1 2 3]
  [4 5 6]]
-?> m@[[] 2] :" get all rows from column 2"
+?> m@[[] 2] :" get all rows from column 2"                # m[:,2]
 [3 6]
 ```
 

--- a/tests/test_numpy_slice.py
+++ b/tests/test_numpy_slice.py
@@ -1,42 +1,55 @@
 import unittest
+import numpy as np
 from utils import eval_cmp
 from klongpy import KlongInterpreter
+from klongpy.core import kg_write
 
 class TestNumpySliceBehavior(unittest.TestCase):
     def assert_eval_cmp(self, a, b, klong=None):
         self.assertTrue(eval_cmp(a, b, klong=klong))
 
     def test_reshape_wildcard(self):
-        self.assert_eval_cmp('[2 []]:^[1 2 3 4]', '[[1 2] [3 4]]')
+        """np.array([1,2,3,4]).reshape(2, -1)"""
+        expected = np.array([1, 2, 3, 4]).reshape(2, -1)
+        self.assert_eval_cmp('[2 []]:^[1 2 3 4]', kg_write(expected))
 
     def test_index_in_depth_wildcard(self):
-        self.assert_eval_cmp('[[1 2 3] [4 5 6]]:@[[] 1]', '[2 5]')
+        """np.array([[1,2,3],[4,5,6]])[:,1]"""
+        expected = np.array([[1,2,3],[4,5,6]])[:,1]
+        self.assert_eval_cmp('[[1 2 3] [4 5 6]]:@[[] 1]', kg_write(expected))
 
     def test_reshape_wildcard_front(self):
-        """Wildcard as the first dimension"""
-        self.assert_eval_cmp('[[] 2]:^[1 2 3 4 5 6]', '[[1 2] [3 4] [5 6]]')
+        """Wildcard as the first dimension. np.array([1,2,3,4,5,6]).reshape(-1, 2)"""
+        expected = np.array([1,2,3,4,5,6]).reshape(-1,2)
+        self.assert_eval_cmp('[[] 2]:^[1 2 3 4 5 6]', kg_write(expected))
 
     def test_index_row_wildcard(self):
-        """Select entire first row using wildcard"""
-        self.assert_eval_cmp('[[1 2 3] [4 5 6]]:@[0 []]', '[1 2 3]')
+        """Select entire first row using wildcard. np.array([[1,2,3],[4,5,6]])[0,:]"""
+        expected = np.array([[1,2,3],[4,5,6]])[0,:]
+        self.assert_eval_cmp('[[1 2 3] [4 5 6]]:@[0 []]', kg_write(expected))
 
     def test_index_column_wildcard(self):
-        """Select entire third column using wildcard"""
-        self.assert_eval_cmp('[[1 2 3] [4 5 6]]:@[[] 2]', '[3 6]')
+        """Select entire third column using wildcard. np.array([[1,2,3],[4,5,6]])[:,2]"""
+        expected = np.array([[1,2,3],[4,5,6]])[:,2]
+        self.assert_eval_cmp('[[1 2 3] [4 5 6]]:@[[] 2]', kg_write(expected))
 
     def test_index_negative_row(self):
-        """Use negative index for last row"""
-        self.assert_eval_cmp('[[1 2 3] [4 5 6]]:@[-1 []]', '[4 5 6]')
+        """Use negative index for last row. np.array([[1,2,3],[4,5,6]])[-1,:]"""
+        expected = np.array([[1,2,3],[4,5,6]])[-1,:]
+        self.assert_eval_cmp('[[1 2 3] [4 5 6]]:@[-1 []]', kg_write(expected))
 
     def test_index_negative_column(self):
-        """Use negative index for last column"""
-        self.assert_eval_cmp('[[1 2 3] [4 5 6]]:@[[] -1]', '[3 6]')
+        """Use negative index for last column. np.array([[1,2,3],[4,5,6]])[:,-1]"""
+        expected = np.array([[1,2,3],[4,5,6]])[:,-1]
+        self.assert_eval_cmp('[[1 2 3] [4 5 6]]:@[[] -1]', kg_write(expected))
 
     def test_index_entire_matrix(self):
-        """Wildcard for all rows and columns"""
-        self.assert_eval_cmp('[[1 2 3] [4 5 6]]:@[[] []]', '[[1 2 3] [4 5 6]]')
+        """Wildcard for all rows and columns. np.array([[1,2,3],[4,5,6]])[:, :]"""
+        expected = np.array([[1,2,3],[4,5,6]])[:, :]
+        self.assert_eval_cmp('[[1 2 3] [4 5 6]]:@[[] []]', kg_write(expected))
 
     def test_index_3d_wildcard(self):
-        """Indexing into 3D array with wildcard"""
+        """Indexing into 3D array with wildcard. np.array([[[1,2],[3,4]],[[5,6],[7,8]]])[1,0,:]"""
         expr = '[[[1 2] [3 4]] [[5 6] [7 8]]]:@[1 0 []]'
-        self.assert_eval_cmp(expr, '[5 6]')
+        expected = np.array([[[1,2],[3,4]],[[5,6],[7,8]]])[1,0,:]
+        self.assert_eval_cmp(expr, kg_write(expected))


### PR DESCRIPTION
## Summary
- expand `tests/test_numpy_slice.py` docstrings to include the NumPy equivalent for each slice
- annotate README slicing example with NumPy comments
- use `kg_write` to stringify NumPy results in tests

## Testing
- `python3 -m unittest`

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.