### PR TITLE
Document REPL webserver start

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,31 @@ $ curl http://localhost:8888
 ['Hello, Klong World! ' 0 1 2 3 4 5 6 7 8 9]
 ```
 
+You can also spin up this server directly inside the REPL:
+
+```kgpy
+?> .py("klongpy.web")
+?> data::!10
+?> index::{x; "Hello, Klong World! ", data}
+?> get:::{}; get,"/",index
+?> post:::{}
+?> h::.web(8888;get;post)
+```
+
+And from another terminal:
+
+```bash
+$ curl http://localhost:8888
+['Hello, Klong World! ' 0 1 2 3 4 5 6 7 8 9]
+```
+
+Stop the server with:
+
+```kgpy
+?> .webc(h)
+1
+```
+
 ## Conclusion
 
 These examples are designed to illustrate the "batteries included" approach, ease of use and diverse applications of KlongPy, making it a versatile choice for various programming needs.

--- a/docs/web_server.md
+++ b/docs/web_server.md
@@ -52,3 +52,28 @@ $ curl -X POST -d"p=100" "http://localhost:8888/p"
 $ curl "http://localhost:8888"
 [100]
 ```
+
+You can also launch the same web server directly from the REPL:
+
+```kgpy
+?> .py("klongpy.web")
+?> data::!10
+?> index::{x; "Hello, Klong World! ", data}
+?> get:::{}; get,"/",index
+?> post:::{}
+?> h::.web(8888;get;post)
+```
+
+Now in another terminal:
+
+```bash
+$ curl http://localhost:8888
+['Hello, Klong World! ' 0 1 2 3 4 5 6 7 8 9]
+```
+
+Stop the server with:
+
+```kgpy
+?> .webc(h)
+1
+```


### PR DESCRIPTION
## Summary
- document how to launch the web server from inside the REPL
- show same workflow in the Web Server docs

## Testing
- `python3 -m unittest`