### PR TITLE
Fix backend jagged array check and add comparison ops

### DIFF
--- a/klongpy/core.py
+++ b/klongpy/core.py
@@ -5,6 +5,7 @@ from enum import Enum
 import sys
 
 from .backend import np
+import numpy as _numpy
 
 # python3.11 support
 if not hasattr(inspect, 'getargspec'):
@@ -261,9 +262,12 @@ def kg_asarray(a):
     """
     if isinstance(a, str):
         return str_to_chr_arr(a)
+    if isinstance(a, _numpy.ndarray):
+        return a
     try:
         arr = np.asarray(a)
-        if arr.dtype.kind not in ['O','i','f']:
+        kind = getattr(getattr(arr, 'dtype', None), 'kind', None)
+        if kind is not None and kind not in ['O','i','f']:
             raise ValueError
     except (np.VisibleDeprecationWarning, ValueError):
         try:
@@ -582,7 +586,8 @@ def read_list(t, delim, i=0, module=None, level=1):
         i += 1
     if level == 1:
         aa = kg_asarray(arr)
-        if aa.dtype.kind not in ['O','i','f']:
+        kind = getattr(getattr(aa, 'dtype', None), 'kind', None)
+        if kind is not None and kind not in ['O','i','f']:
             aa = np.asarray(arr, dtype=object)
     else:
         aa = arr

--- a/klongpy/dyads.py
+++ b/klongpy/dyads.py
@@ -957,9 +957,14 @@ def eval_dyad_take(a, b):
     j = isinstance(b,str)
     b = str_to_chr_arr(b) if j else np.asarray(b)
     aa = np.abs(a)
-    if aa > b.size:
-        b = np.tile(b,aa // len(b))
-        b = np.concatenate((b, b[:aa-b.size]) if a > 0 else (b[-(aa-b.size):],b))
+    size = b.numel() if hasattr(b, 'numel') else b.size
+    if size == 0:
+        return "" if j else b[:0]
+    if aa > size:
+        b = np.tile(b, aa // len(b) if len(b) else 0)
+        size = b.numel() if hasattr(b, 'numel') else b.size
+        if aa > size:
+            b = np.concatenate((b, b[:aa-size]) if a > 0 else (b[-(aa-size):], b))
     r = b[a:] if a < 0 else b[:a]
     return "".join(r) if j else r
 


### PR DESCRIPTION
## Summary
- add tensor subclass wrapper with helper methods for torch
- implement comparison and math helpers in Torch backend
- handle numpy arrays in `kg_asarray` and jagged detection
- adapt take dyad for torch tensors

## Testing
- `USE_TORCH=1 python3 -m unittest` *(fails: many tests still failing)*