### PR TITLE
Add multi-arch build workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,50 @@
+name: Build and Publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build_wheels:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.11
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install cibuildwheel==2.16.5 build
+      - name: Build wheels
+        run: |
+          python -m build --sdist -o dist
+          python -m cibuildwheel --output-dir dist
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheels-${{ matrix.os }}
+          path: dist
+
+  publish:
+    needs: build_wheels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: dist
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+        run: |
+          python -m pip install --upgrade pip
+          pip install twine
+          twine upload dist/**/klongpy-*.whl dist/**/klongpy-*.tar.gz

--- a/README.md
+++ b/README.md
@@ -389,6 +389,21 @@ python3 setup.py develop
 python3 -m unittest
 ```
 
+### Building and Publishing
+
+The project uses [cibuildwheel](https://github.com/pypa/cibuildwheel) to build
+wheels for multiple CPU architectures.  A GitHub Actions workflow automatically
+builds and uploads these artifacts to PyPI whenever a release is published.
+To build wheels locally, run:
+
+```bash
+python -m pip install build cibuildwheel
+python -m build --sdist -o dist
+python -m cibuildwheel --output-dir dist
+```
+
+You can then upload the contents of the `dist/` directory with `twine`.
+
 # Acknowledgement
 
 HUGE thanks to Nils M Holm for his work on Klong and providing the foundations for this interesting project.

--- a/push_pypi.sh
+++ b/push_pypi.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 rm -rf dist
-python3 setup.py sdist bdist_wheel
+python -m pip install --upgrade build cibuildwheel twine
+python -m build --sdist -o dist
+python -m cibuildwheel --output-dir dist
 twine upload dist/*
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- automate wheel creation for Linux, macOS and Windows using cibuildwheel
- upload packages to PyPI on new releases
- document building & publishing process
- modernize push script for cibuildwheel
- add pyproject.toml build configuration

## Testing
- `python3 -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_68539ff87b84833286ae9561762268f3