### PR TITLE
Setup GitHub Pages docs

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,21 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install mkdocs mkdocs-material
+      - name: Build and deploy
+        run: mkdocs gh-deploy --force

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ KlongPy is a Python adaptation of the [Klong](https://t3x.org/klong) [array lang
 - **Ideal for Diverse Fields:** Data scientists, quantitative analysts, researchers, and programming language enthusiasts will find KlongPy especially beneficial for its versatility and performance.
 
 KlongPy thus stands as a robust tool, blending the simplicity of Klong with the extensive capabilities of Python, suitable for a wide range of computational tasks.
+## Documentation
+
+Full documentation is available at [https://briangu.github.io/klongpy](https://briangu.github.io/klongpy).
+
 
 # Quick install
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: KlongPy
-site_url: https://your-site-url.com
+site_url: https://briangu.github.io/klongpy
 
 # Define the source directory for Markdown files
 docs_dir: 'docs'


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to deploy docs with MkDocs
- link to the docs on GitHub Pages
- configure `mkdocs.yml` with the GitHub Pages URL

## Testing
- `python3 -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_685a911998b083328b61a9a554c98624