### PR TITLE
Add map operation with lambda support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,6 @@
+[workspace]
+members = [
+    "crates/klong-core",
+    "crates/klong-py"
+]
+resolver = "2"

--- a/crates/klong-core/Cargo.toml
+++ b/crates/klong-core/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "klong-core"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rayon = "1"
+
+[dependencies.duckdb]
+version = "0.10"
+optional = true
+
+[dependencies.arrow]
+version = "51"
+features = ["ffi"]
+optional = true
+
+[features]
+default = []
+duckdb = ["dep:duckdb", "dep:arrow"]

--- a/crates/klong-core/src/array.rs
+++ b/crates/klong-core/src/array.rs
@@ -1,0 +1,18 @@
+#[derive(Clone)]
+pub struct Array<T> {
+    pub data: Vec<T>,
+    pub shape: Vec<usize>,
+    pub strides: Vec<usize>,
+}
+
+impl<T: Clone> Array<T> {
+    pub fn from_slice(slice: &[T], shape: &[usize]) -> Self {
+        let data = slice.to_vec();
+        let shape = shape.to_vec();
+        let mut strides = vec![1; shape.len()];
+        for i in (1..shape.len()).rev() {
+            strides[i - 1] = strides[i] * shape[i];
+        }
+        Self { data, shape, strides }
+    }
+}

--- a/crates/klong-core/src/kernels.rs
+++ b/crates/klong-core/src/kernels.rs
@@ -1,18 +1,27 @@
-use core::simd::Simd;
 use rayon::prelude::*;
+
+#[cfg(target_arch = "x86_64")]
+use std::arch::x86_64::*;
 
 pub fn simd_add_inplace(a: &mut [f64], b: &[f64]) {
     assert_eq!(a.len(), b.len());
-    const LANES: usize = 8;
-    let chunks = a.len() / LANES;
-    for i in 0..chunks {
-        let start = i * LANES;
-        let va = Simd::<f64, LANES>::from_slice(&a[start..start + LANES]);
-        let vb = Simd::<f64, LANES>::from_slice(&b[start..start + LANES]);
-        let vc = va + vb;
-        vc.write_to_slice(&mut a[start..start + LANES]);
+    #[cfg(target_arch = "x86_64")]
+    unsafe {
+        let mut i = 0;
+        let chunks = a.len() / 2;
+        while i < chunks * 2 {
+            let va = _mm_loadu_pd(a.as_ptr().add(i));
+            let vb = _mm_loadu_pd(b.as_ptr().add(i));
+            let vc = _mm_add_pd(va, vb);
+            _mm_storeu_pd(a.as_mut_ptr().add(i), vc);
+            i += 2;
+        }
+        for j in i..a.len() {
+            a[j] += b[j];
+        }
+        return;
     }
-    for i in chunks * LANES..a.len() {
+    for i in 0..a.len() {
         a[i] += b[i];
     }
 }
@@ -27,16 +36,23 @@ pub fn par_add_inplace(a: &mut [f64], b: &[f64]) {
 
 pub fn simd_sub_inplace(a: &mut [f64], b: &[f64]) {
     assert_eq!(a.len(), b.len());
-    const LANES: usize = 8;
-    let chunks = a.len() / LANES;
-    for i in 0..chunks {
-        let start = i * LANES;
-        let va = Simd::<f64, LANES>::from_slice(&a[start..start + LANES]);
-        let vb = Simd::<f64, LANES>::from_slice(&b[start..start + LANES]);
-        let vc = va - vb;
-        vc.write_to_slice(&mut a[start..start + LANES]);
+    #[cfg(target_arch = "x86_64")]
+    unsafe {
+        let mut i = 0;
+        let chunks = a.len() / 2;
+        while i < chunks * 2 {
+            let va = _mm_loadu_pd(a.as_ptr().add(i));
+            let vb = _mm_loadu_pd(b.as_ptr().add(i));
+            let vc = _mm_sub_pd(va, vb);
+            _mm_storeu_pd(a.as_mut_ptr().add(i), vc);
+            i += 2;
+        }
+        for j in i..a.len() {
+            a[j] -= b[j];
+        }
+        return;
     }
-    for i in chunks * LANES..a.len() {
+    for i in 0..a.len() {
         a[i] -= b[i];
     }
 }
@@ -51,16 +67,23 @@ pub fn par_sub_inplace(a: &mut [f64], b: &[f64]) {
 
 pub fn simd_mul_inplace(a: &mut [f64], b: &[f64]) {
     assert_eq!(a.len(), b.len());
-    const LANES: usize = 8;
-    let chunks = a.len() / LANES;
-    for i in 0..chunks {
-        let start = i * LANES;
-        let va = Simd::<f64, LANES>::from_slice(&a[start..start + LANES]);
-        let vb = Simd::<f64, LANES>::from_slice(&b[start..start + LANES]);
-        let vc = va * vb;
-        vc.write_to_slice(&mut a[start..start + LANES]);
+    #[cfg(target_arch = "x86_64")]
+    unsafe {
+        let mut i = 0;
+        let chunks = a.len() / 2;
+        while i < chunks * 2 {
+            let va = _mm_loadu_pd(a.as_ptr().add(i));
+            let vb = _mm_loadu_pd(b.as_ptr().add(i));
+            let vc = _mm_mul_pd(va, vb);
+            _mm_storeu_pd(a.as_mut_ptr().add(i), vc);
+            i += 2;
+        }
+        for j in i..a.len() {
+            a[j] *= b[j];
+        }
+        return;
     }
-    for i in chunks * LANES..a.len() {
+    for i in 0..a.len() {
         a[i] *= b[i];
     }
 }
@@ -75,16 +98,23 @@ pub fn par_mul_inplace(a: &mut [f64], b: &[f64]) {
 
 pub fn simd_div_inplace(a: &mut [f64], b: &[f64]) {
     assert_eq!(a.len(), b.len());
-    const LANES: usize = 8;
-    let chunks = a.len() / LANES;
-    for i in 0..chunks {
-        let start = i * LANES;
-        let va = Simd::<f64, LANES>::from_slice(&a[start..start + LANES]);
-        let vb = Simd::<f64, LANES>::from_slice(&b[start..start + LANES]);
-        let vc = va / vb;
-        vc.write_to_slice(&mut a[start..start + LANES]);
+    #[cfg(target_arch = "x86_64")]
+    unsafe {
+        let mut i = 0;
+        let chunks = a.len() / 2;
+        while i < chunks * 2 {
+            let va = _mm_loadu_pd(a.as_ptr().add(i));
+            let vb = _mm_loadu_pd(b.as_ptr().add(i));
+            let vc = _mm_div_pd(va, vb);
+            _mm_storeu_pd(a.as_mut_ptr().add(i), vc);
+            i += 2;
+        }
+        for j in i..a.len() {
+            a[j] /= b[j];
+        }
+        return;
     }
-    for i in chunks * LANES..a.len() {
+    for i in 0..a.len() {
         a[i] /= b[i];
     }
 }
@@ -99,16 +129,23 @@ pub fn par_div_inplace(a: &mut [f64], b: &[f64]) {
 
 pub fn simd_add_inplace_f32(a: &mut [f32], b: &[f32]) {
     assert_eq!(a.len(), b.len());
-    const LANES: usize = 8;
-    let chunks = a.len() / LANES;
-    for i in 0..chunks {
-        let start = i * LANES;
-        let va = Simd::<f32, LANES>::from_slice(&a[start..start + LANES]);
-        let vb = Simd::<f32, LANES>::from_slice(&b[start..start + LANES]);
-        let vc = va + vb;
-        vc.write_to_slice(&mut a[start..start + LANES]);
+    #[cfg(target_arch = "x86_64")]
+    unsafe {
+        let mut i = 0;
+        let chunks = a.len() / 4;
+        while i < chunks * 4 {
+            let va = _mm_loadu_ps(a.as_ptr().add(i));
+            let vb = _mm_loadu_ps(b.as_ptr().add(i));
+            let vc = _mm_add_ps(va, vb);
+            _mm_storeu_ps(a.as_mut_ptr().add(i), vc);
+            i += 4;
+        }
+        for j in i..a.len() {
+            a[j] += b[j];
+        }
+        return;
     }
-    for i in chunks * LANES..a.len() {
+    for i in 0..a.len() {
         a[i] += b[i];
     }
 }
@@ -123,16 +160,23 @@ pub fn par_add_inplace_f32(a: &mut [f32], b: &[f32]) {
 
 pub fn simd_sub_inplace_f32(a: &mut [f32], b: &[f32]) {
     assert_eq!(a.len(), b.len());
-    const LANES: usize = 8;
-    let chunks = a.len() / LANES;
-    for i in 0..chunks {
-        let start = i * LANES;
-        let va = Simd::<f32, LANES>::from_slice(&a[start..start + LANES]);
-        let vb = Simd::<f32, LANES>::from_slice(&b[start..start + LANES]);
-        let vc = va - vb;
-        vc.write_to_slice(&mut a[start..start + LANES]);
+    #[cfg(target_arch = "x86_64")]
+    unsafe {
+        let mut i = 0;
+        let chunks = a.len() / 4;
+        while i < chunks * 4 {
+            let va = _mm_loadu_ps(a.as_ptr().add(i));
+            let vb = _mm_loadu_ps(b.as_ptr().add(i));
+            let vc = _mm_sub_ps(va, vb);
+            _mm_storeu_ps(a.as_mut_ptr().add(i), vc);
+            i += 4;
+        }
+        for j in i..a.len() {
+            a[j] -= b[j];
+        }
+        return;
     }
-    for i in chunks * LANES..a.len() {
+    for i in 0..a.len() {
         a[i] -= b[i];
     }
 }
@@ -147,16 +191,23 @@ pub fn par_sub_inplace_f32(a: &mut [f32], b: &[f32]) {
 
 pub fn simd_mul_inplace_f32(a: &mut [f32], b: &[f32]) {
     assert_eq!(a.len(), b.len());
-    const LANES: usize = 8;
-    let chunks = a.len() / LANES;
-    for i in 0..chunks {
-        let start = i * LANES;
-        let va = Simd::<f32, LANES>::from_slice(&a[start..start + LANES]);
-        let vb = Simd::<f32, LANES>::from_slice(&b[start..start + LANES]);
-        let vc = va * vb;
-        vc.write_to_slice(&mut a[start..start + LANES]);
+    #[cfg(target_arch = "x86_64")]
+    unsafe {
+        let mut i = 0;
+        let chunks = a.len() / 4;
+        while i < chunks * 4 {
+            let va = _mm_loadu_ps(a.as_ptr().add(i));
+            let vb = _mm_loadu_ps(b.as_ptr().add(i));
+            let vc = _mm_mul_ps(va, vb);
+            _mm_storeu_ps(a.as_mut_ptr().add(i), vc);
+            i += 4;
+        }
+        for j in i..a.len() {
+            a[j] *= b[j];
+        }
+        return;
     }
-    for i in chunks * LANES..a.len() {
+    for i in 0..a.len() {
         a[i] *= b[i];
     }
 }
@@ -171,16 +222,23 @@ pub fn par_mul_inplace_f32(a: &mut [f32], b: &[f32]) {
 
 pub fn simd_div_inplace_f32(a: &mut [f32], b: &[f32]) {
     assert_eq!(a.len(), b.len());
-    const LANES: usize = 8;
-    let chunks = a.len() / LANES;
-    for i in 0..chunks {
-        let start = i * LANES;
-        let va = Simd::<f32, LANES>::from_slice(&a[start..start + LANES]);
-        let vb = Simd::<f32, LANES>::from_slice(&b[start..start + LANES]);
-        let vc = va / vb;
-        vc.write_to_slice(&mut a[start..start + LANES]);
+    #[cfg(target_arch = "x86_64")]
+    unsafe {
+        let mut i = 0;
+        let chunks = a.len() / 4;
+        while i < chunks * 4 {
+            let va = _mm_loadu_ps(a.as_ptr().add(i));
+            let vb = _mm_loadu_ps(b.as_ptr().add(i));
+            let vc = _mm_div_ps(va, vb);
+            _mm_storeu_ps(a.as_mut_ptr().add(i), vc);
+            i += 4;
+        }
+        for j in i..a.len() {
+            a[j] /= b[j];
+        }
+        return;
     }
-    for i in chunks * LANES..a.len() {
+    for i in 0..a.len() {
         a[i] /= b[i];
     }
 }

--- a/crates/klong-core/src/kernels.rs
+++ b/crates/klong-core/src/kernels.rs
@@ -2,6 +2,8 @@ use rayon::prelude::*;
 
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
+#[cfg(target_arch = "aarch64")]
+use std::arch::aarch64::*;
 
 pub fn simd_add_inplace(a: &mut [f64], b: &[f64]) {
     assert_eq!(a.len(), b.len());
@@ -14,6 +16,22 @@ pub fn simd_add_inplace(a: &mut [f64], b: &[f64]) {
             let vb = _mm_loadu_pd(b.as_ptr().add(i));
             let vc = _mm_add_pd(va, vb);
             _mm_storeu_pd(a.as_mut_ptr().add(i), vc);
+            i += 2;
+        }
+        for j in i..a.len() {
+            a[j] += b[j];
+        }
+        return;
+    }
+    #[cfg(target_arch = "aarch64")]
+    unsafe {
+        let mut i = 0;
+        let chunks = a.len() / 2;
+        while i < chunks * 2 {
+            let va = vld1q_f64(a.as_ptr().add(i));
+            let vb = vld1q_f64(b.as_ptr().add(i));
+            let vc = vaddq_f64(va, vb);
+            vst1q_f64(a.as_mut_ptr().add(i), vc);
             i += 2;
         }
         for j in i..a.len() {
@@ -52,6 +70,22 @@ pub fn simd_sub_inplace(a: &mut [f64], b: &[f64]) {
         }
         return;
     }
+    #[cfg(target_arch = "aarch64")]
+    unsafe {
+        let mut i = 0;
+        let chunks = a.len() / 2;
+        while i < chunks * 2 {
+            let va = vld1q_f64(a.as_ptr().add(i));
+            let vb = vld1q_f64(b.as_ptr().add(i));
+            let vc = vsubq_f64(va, vb);
+            vst1q_f64(a.as_mut_ptr().add(i), vc);
+            i += 2;
+        }
+        for j in i..a.len() {
+            a[j] -= b[j];
+        }
+        return;
+    }
     for i in 0..a.len() {
         a[i] -= b[i];
     }
@@ -76,6 +110,22 @@ pub fn simd_mul_inplace(a: &mut [f64], b: &[f64]) {
             let vb = _mm_loadu_pd(b.as_ptr().add(i));
             let vc = _mm_mul_pd(va, vb);
             _mm_storeu_pd(a.as_mut_ptr().add(i), vc);
+            i += 2;
+        }
+        for j in i..a.len() {
+            a[j] *= b[j];
+        }
+        return;
+    }
+    #[cfg(target_arch = "aarch64")]
+    unsafe {
+        let mut i = 0;
+        let chunks = a.len() / 2;
+        while i < chunks * 2 {
+            let va = vld1q_f64(a.as_ptr().add(i));
+            let vb = vld1q_f64(b.as_ptr().add(i));
+            let vc = vmulq_f64(va, vb);
+            vst1q_f64(a.as_mut_ptr().add(i), vc);
             i += 2;
         }
         for j in i..a.len() {
@@ -114,6 +164,22 @@ pub fn simd_div_inplace(a: &mut [f64], b: &[f64]) {
         }
         return;
     }
+    #[cfg(target_arch = "aarch64")]
+    unsafe {
+        let mut i = 0;
+        let chunks = a.len() / 2;
+        while i < chunks * 2 {
+            let va = vld1q_f64(a.as_ptr().add(i));
+            let vb = vld1q_f64(b.as_ptr().add(i));
+            let vc = vdivq_f64(va, vb);
+            vst1q_f64(a.as_mut_ptr().add(i), vc);
+            i += 2;
+        }
+        for j in i..a.len() {
+            a[j] /= b[j];
+        }
+        return;
+    }
     for i in 0..a.len() {
         a[i] /= b[i];
     }
@@ -138,6 +204,22 @@ pub fn simd_add_inplace_f32(a: &mut [f32], b: &[f32]) {
             let vb = _mm_loadu_ps(b.as_ptr().add(i));
             let vc = _mm_add_ps(va, vb);
             _mm_storeu_ps(a.as_mut_ptr().add(i), vc);
+            i += 4;
+        }
+        for j in i..a.len() {
+            a[j] += b[j];
+        }
+        return;
+    }
+    #[cfg(target_arch = "aarch64")]
+    unsafe {
+        let mut i = 0;
+        let chunks = a.len() / 4;
+        while i < chunks * 4 {
+            let va = vld1q_f32(a.as_ptr().add(i));
+            let vb = vld1q_f32(b.as_ptr().add(i));
+            let vc = vaddq_f32(va, vb);
+            vst1q_f32(a.as_mut_ptr().add(i), vc);
             i += 4;
         }
         for j in i..a.len() {
@@ -176,6 +258,22 @@ pub fn simd_sub_inplace_f32(a: &mut [f32], b: &[f32]) {
         }
         return;
     }
+    #[cfg(target_arch = "aarch64")]
+    unsafe {
+        let mut i = 0;
+        let chunks = a.len() / 4;
+        while i < chunks * 4 {
+            let va = vld1q_f32(a.as_ptr().add(i));
+            let vb = vld1q_f32(b.as_ptr().add(i));
+            let vc = vsubq_f32(va, vb);
+            vst1q_f32(a.as_mut_ptr().add(i), vc);
+            i += 4;
+        }
+        for j in i..a.len() {
+            a[j] -= b[j];
+        }
+        return;
+    }
     for i in 0..a.len() {
         a[i] -= b[i];
     }
@@ -207,6 +305,22 @@ pub fn simd_mul_inplace_f32(a: &mut [f32], b: &[f32]) {
         }
         return;
     }
+    #[cfg(target_arch = "aarch64")]
+    unsafe {
+        let mut i = 0;
+        let chunks = a.len() / 4;
+        while i < chunks * 4 {
+            let va = vld1q_f32(a.as_ptr().add(i));
+            let vb = vld1q_f32(b.as_ptr().add(i));
+            let vc = vmulq_f32(va, vb);
+            vst1q_f32(a.as_mut_ptr().add(i), vc);
+            i += 4;
+        }
+        for j in i..a.len() {
+            a[j] *= b[j];
+        }
+        return;
+    }
     for i in 0..a.len() {
         a[i] *= b[i];
     }
@@ -231,6 +345,22 @@ pub fn simd_div_inplace_f32(a: &mut [f32], b: &[f32]) {
             let vb = _mm_loadu_ps(b.as_ptr().add(i));
             let vc = _mm_div_ps(va, vb);
             _mm_storeu_ps(a.as_mut_ptr().add(i), vc);
+            i += 4;
+        }
+        for j in i..a.len() {
+            a[j] /= b[j];
+        }
+        return;
+    }
+    #[cfg(target_arch = "aarch64")]
+    unsafe {
+        let mut i = 0;
+        let chunks = a.len() / 4;
+        while i < chunks * 4 {
+            let va = vld1q_f32(a.as_ptr().add(i));
+            let vb = vld1q_f32(b.as_ptr().add(i));
+            let vc = vdivq_f32(va, vb);
+            vst1q_f32(a.as_mut_ptr().add(i), vc);
             i += 4;
         }
         for j in i..a.len() {

--- a/crates/klong-core/src/kernels.rs
+++ b/crates/klong-core/src/kernels.rs
@@ -1,0 +1,212 @@
+use core::simd::Simd;
+use rayon::prelude::*;
+
+pub fn simd_add_inplace(a: &mut [f64], b: &[f64]) {
+    assert_eq!(a.len(), b.len());
+    const LANES: usize = 8;
+    let chunks = a.len() / LANES;
+    for i in 0..chunks {
+        let start = i * LANES;
+        let va = Simd::<f64, LANES>::from_slice(&a[start..start + LANES]);
+        let vb = Simd::<f64, LANES>::from_slice(&b[start..start + LANES]);
+        let vc = va + vb;
+        vc.write_to_slice(&mut a[start..start + LANES]);
+    }
+    for i in chunks * LANES..a.len() {
+        a[i] += b[i];
+    }
+}
+
+pub fn par_add_inplace(a: &mut [f64], b: &[f64]) {
+    assert_eq!(a.len(), b.len());
+    const CHUNK: usize = 1024;
+    a.par_chunks_mut(CHUNK)
+        .zip(b.par_chunks(CHUNK))
+        .for_each(|(ac, bc)| simd_add_inplace(ac, bc));
+}
+
+pub fn simd_sub_inplace(a: &mut [f64], b: &[f64]) {
+    assert_eq!(a.len(), b.len());
+    const LANES: usize = 8;
+    let chunks = a.len() / LANES;
+    for i in 0..chunks {
+        let start = i * LANES;
+        let va = Simd::<f64, LANES>::from_slice(&a[start..start + LANES]);
+        let vb = Simd::<f64, LANES>::from_slice(&b[start..start + LANES]);
+        let vc = va - vb;
+        vc.write_to_slice(&mut a[start..start + LANES]);
+    }
+    for i in chunks * LANES..a.len() {
+        a[i] -= b[i];
+    }
+}
+
+pub fn par_sub_inplace(a: &mut [f64], b: &[f64]) {
+    assert_eq!(a.len(), b.len());
+    const CHUNK: usize = 1024;
+    a.par_chunks_mut(CHUNK)
+        .zip(b.par_chunks(CHUNK))
+        .for_each(|(ac, bc)| simd_sub_inplace(ac, bc));
+}
+
+pub fn simd_mul_inplace(a: &mut [f64], b: &[f64]) {
+    assert_eq!(a.len(), b.len());
+    const LANES: usize = 8;
+    let chunks = a.len() / LANES;
+    for i in 0..chunks {
+        let start = i * LANES;
+        let va = Simd::<f64, LANES>::from_slice(&a[start..start + LANES]);
+        let vb = Simd::<f64, LANES>::from_slice(&b[start..start + LANES]);
+        let vc = va * vb;
+        vc.write_to_slice(&mut a[start..start + LANES]);
+    }
+    for i in chunks * LANES..a.len() {
+        a[i] *= b[i];
+    }
+}
+
+pub fn par_mul_inplace(a: &mut [f64], b: &[f64]) {
+    assert_eq!(a.len(), b.len());
+    const CHUNK: usize = 1024;
+    a.par_chunks_mut(CHUNK)
+        .zip(b.par_chunks(CHUNK))
+        .for_each(|(ac, bc)| simd_mul_inplace(ac, bc));
+}
+
+pub fn simd_div_inplace(a: &mut [f64], b: &[f64]) {
+    assert_eq!(a.len(), b.len());
+    const LANES: usize = 8;
+    let chunks = a.len() / LANES;
+    for i in 0..chunks {
+        let start = i * LANES;
+        let va = Simd::<f64, LANES>::from_slice(&a[start..start + LANES]);
+        let vb = Simd::<f64, LANES>::from_slice(&b[start..start + LANES]);
+        let vc = va / vb;
+        vc.write_to_slice(&mut a[start..start + LANES]);
+    }
+    for i in chunks * LANES..a.len() {
+        a[i] /= b[i];
+    }
+}
+
+pub fn par_div_inplace(a: &mut [f64], b: &[f64]) {
+    assert_eq!(a.len(), b.len());
+    const CHUNK: usize = 1024;
+    a.par_chunks_mut(CHUNK)
+        .zip(b.par_chunks(CHUNK))
+        .for_each(|(ac, bc)| simd_div_inplace(ac, bc));
+}
+
+pub fn simd_add_inplace_f32(a: &mut [f32], b: &[f32]) {
+    assert_eq!(a.len(), b.len());
+    const LANES: usize = 8;
+    let chunks = a.len() / LANES;
+    for i in 0..chunks {
+        let start = i * LANES;
+        let va = Simd::<f32, LANES>::from_slice(&a[start..start + LANES]);
+        let vb = Simd::<f32, LANES>::from_slice(&b[start..start + LANES]);
+        let vc = va + vb;
+        vc.write_to_slice(&mut a[start..start + LANES]);
+    }
+    for i in chunks * LANES..a.len() {
+        a[i] += b[i];
+    }
+}
+
+pub fn par_add_inplace_f32(a: &mut [f32], b: &[f32]) {
+    assert_eq!(a.len(), b.len());
+    const CHUNK: usize = 1024;
+    a.par_chunks_mut(CHUNK)
+        .zip(b.par_chunks(CHUNK))
+        .for_each(|(ac, bc)| simd_add_inplace_f32(ac, bc));
+}
+
+pub fn simd_sub_inplace_f32(a: &mut [f32], b: &[f32]) {
+    assert_eq!(a.len(), b.len());
+    const LANES: usize = 8;
+    let chunks = a.len() / LANES;
+    for i in 0..chunks {
+        let start = i * LANES;
+        let va = Simd::<f32, LANES>::from_slice(&a[start..start + LANES]);
+        let vb = Simd::<f32, LANES>::from_slice(&b[start..start + LANES]);
+        let vc = va - vb;
+        vc.write_to_slice(&mut a[start..start + LANES]);
+    }
+    for i in chunks * LANES..a.len() {
+        a[i] -= b[i];
+    }
+}
+
+pub fn par_sub_inplace_f32(a: &mut [f32], b: &[f32]) {
+    assert_eq!(a.len(), b.len());
+    const CHUNK: usize = 1024;
+    a.par_chunks_mut(CHUNK)
+        .zip(b.par_chunks(CHUNK))
+        .for_each(|(ac, bc)| simd_sub_inplace_f32(ac, bc));
+}
+
+pub fn simd_mul_inplace_f32(a: &mut [f32], b: &[f32]) {
+    assert_eq!(a.len(), b.len());
+    const LANES: usize = 8;
+    let chunks = a.len() / LANES;
+    for i in 0..chunks {
+        let start = i * LANES;
+        let va = Simd::<f32, LANES>::from_slice(&a[start..start + LANES]);
+        let vb = Simd::<f32, LANES>::from_slice(&b[start..start + LANES]);
+        let vc = va * vb;
+        vc.write_to_slice(&mut a[start..start + LANES]);
+    }
+    for i in chunks * LANES..a.len() {
+        a[i] *= b[i];
+    }
+}
+
+pub fn par_mul_inplace_f32(a: &mut [f32], b: &[f32]) {
+    assert_eq!(a.len(), b.len());
+    const CHUNK: usize = 1024;
+    a.par_chunks_mut(CHUNK)
+        .zip(b.par_chunks(CHUNK))
+        .for_each(|(ac, bc)| simd_mul_inplace_f32(ac, bc));
+}
+
+pub fn simd_div_inplace_f32(a: &mut [f32], b: &[f32]) {
+    assert_eq!(a.len(), b.len());
+    const LANES: usize = 8;
+    let chunks = a.len() / LANES;
+    for i in 0..chunks {
+        let start = i * LANES;
+        let va = Simd::<f32, LANES>::from_slice(&a[start..start + LANES]);
+        let vb = Simd::<f32, LANES>::from_slice(&b[start..start + LANES]);
+        let vc = va / vb;
+        vc.write_to_slice(&mut a[start..start + LANES]);
+    }
+    for i in chunks * LANES..a.len() {
+        a[i] /= b[i];
+    }
+}
+
+pub fn par_div_inplace_f32(a: &mut [f32], b: &[f32]) {
+    assert_eq!(a.len(), b.len());
+    const CHUNK: usize = 1024;
+    a.par_chunks_mut(CHUNK)
+        .zip(b.par_chunks(CHUNK))
+        .for_each(|(ac, bc)| simd_div_inplace_f32(ac, bc));
+}
+
+pub fn map_inplace_f64<F>(a: &mut [f64], mut f: F)
+where
+    F: FnMut(f64) -> f64,
+{
+    for v in a.iter_mut() {
+        *v = f(*v);
+    }
+}
+
+pub fn map_inplace_f32<F>(a: &mut [f32], mut f: F)
+where
+    F: FnMut(f32) -> f32,
+{
+    for v in a.iter_mut() {
+        *v = f(*v);
+    }
+}

--- a/crates/klong-core/src/lib.rs
+++ b/crates/klong-core/src/lib.rs
@@ -1,0 +1,20 @@
+pub mod array;
+pub mod kernels;
+
+pub use array::Array;
+pub use kernels::{
+    par_add_inplace, par_sub_inplace, par_mul_inplace, par_div_inplace,
+    par_add_inplace_f32, par_sub_inplace_f32, par_mul_inplace_f32,
+    par_div_inplace_f32, map_inplace_f64, map_inplace_f32,
+};
+
+#[cfg(feature = "duckdb")]
+use arrow::record_batch::RecordBatch;
+#[cfg(feature = "duckdb")]
+use duckdb::Result as DuckResult;
+
+#[cfg(feature = "duckdb")]
+pub fn duckdb_query_arrow(_sql: &str, batches: &[RecordBatch]) -> DuckResult<Vec<RecordBatch>> {
+    // Placeholder: real implementation would execute SQL against DuckDB
+    Ok(batches.to_vec())
+}

--- a/crates/klong-py/Cargo.toml
+++ b/crates/klong-py/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "klong-py"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "klongpy_rs"
+crate-type = ["cdylib"]
+
+[dependencies]
+klong-core = { path = "../klong-core" }
+pyo3 = { version = "0.21", features = ["extension-module"] }
+numpy = { version = "0.21", features = ["numpy"] }
+pyo3-ffi = "0.21"
+arrow = { package = "arrow", version = "51", features = ["ffi"] }
+rayon = "1"

--- a/crates/klong-py/src/lib.rs
+++ b/crates/klong-py/src/lib.rs
@@ -1,0 +1,226 @@
+use pyo3::prelude::*;
+use pyo3::exceptions::PyValueError;
+use numpy::{PyArray1, PyReadonlyArray1};
+use klong_core::{
+    par_add_inplace, par_sub_inplace, par_mul_inplace, par_div_inplace,
+    par_add_inplace_f32, par_sub_inplace_f32, par_mul_inplace_f32, par_div_inplace_f32,
+};
+use std::sync::RwLock;
+
+#[derive(Clone, Copy)]
+enum RustDtype {
+    F32,
+    F64,
+}
+
+static DTYPE: RwLock<RustDtype> = RwLock::new(RustDtype::F64);
+
+#[pyclass]
+pub struct PyArrayF64 {
+    inner: klong_core::Array<f64>,
+}
+
+#[pymethods]
+impl PyArrayF64 {
+    #[getter]
+    fn __array_interface__<'py>(&self, py: Python<'py>) -> PyResult<&'py pyo3::types::PyDict> {
+        let dict = pyo3::types::PyDict::new(py);
+        dict.set_item("shape", self.inner.shape.clone())?;
+        dict.set_item("typestr", "<f8")?;
+        dict.set_item("data", (self.inner.data.as_ptr() as usize, false))?;
+        dict.set_item("strides", self.inner.strides.clone())?;
+        Ok(dict)
+    }
+}
+
+#[pyfunction]
+fn add(a: &PyAny, b: &PyAny, py: Python) -> PyResult<PyObject> {
+    match *DTYPE.read().unwrap() {
+        RustDtype::F64 => {
+            let a = a.downcast::<PyReadonlyArray1<f64>>()?;
+            let b = b.downcast::<PyReadonlyArray1<f64>>()?;
+            if a.len() != b.len() {
+                return Err(PyValueError::new_err("length mismatch"));
+            }
+            let out = PyArray1::<f64>::zeros(py, a.len(), false);
+            let mut slice = unsafe { out.as_slice_mut().unwrap() };
+            slice.copy_from_slice(a.as_slice()?);
+            par_add_inplace(&mut slice, b.as_slice()?);
+            Ok(out.into_py(py))
+        }
+        RustDtype::F32 => {
+            let a = a.downcast::<PyReadonlyArray1<f32>>()?;
+            let b = b.downcast::<PyReadonlyArray1<f32>>()?;
+            if a.len() != b.len() {
+                return Err(PyValueError::new_err("length mismatch"));
+            }
+            let out = PyArray1::<f32>::zeros(py, a.len(), false);
+            let mut slice = unsafe { out.as_slice_mut().unwrap() };
+            slice.copy_from_slice(a.as_slice()?);
+            par_add_inplace_f32(&mut slice, b.as_slice()?);
+            Ok(out.into_py(py))
+        }
+    }
+}
+
+#[pyfunction]
+fn subtract(a: &PyAny, b: &PyAny, py: Python) -> PyResult<PyObject> {
+    match *DTYPE.read().unwrap() {
+        RustDtype::F64 => {
+            let a = a.downcast::<PyReadonlyArray1<f64>>()?;
+            let b = b.downcast::<PyReadonlyArray1<f64>>()?;
+            if a.len() != b.len() {
+                return Err(PyValueError::new_err("length mismatch"));
+            }
+            let out = PyArray1::<f64>::zeros(py, a.len(), false);
+            let mut slice = unsafe { out.as_slice_mut().unwrap() };
+            slice.copy_from_slice(a.as_slice()?);
+            par_sub_inplace(&mut slice, b.as_slice()?);
+            Ok(out.into_py(py))
+        }
+        RustDtype::F32 => {
+            let a = a.downcast::<PyReadonlyArray1<f32>>()?;
+            let b = b.downcast::<PyReadonlyArray1<f32>>()?;
+            if a.len() != b.len() {
+                return Err(PyValueError::new_err("length mismatch"));
+            }
+            let out = PyArray1::<f32>::zeros(py, a.len(), false);
+            let mut slice = unsafe { out.as_slice_mut().unwrap() };
+            slice.copy_from_slice(a.as_slice()?);
+            par_sub_inplace_f32(&mut slice, b.as_slice()?);
+            Ok(out.into_py(py))
+        }
+    }
+}
+
+#[pyfunction]
+fn multiply(a: &PyAny, b: &PyAny, py: Python) -> PyResult<PyObject> {
+    match *DTYPE.read().unwrap() {
+        RustDtype::F64 => {
+            let a = a.downcast::<PyReadonlyArray1<f64>>()?;
+            let b = b.downcast::<PyReadonlyArray1<f64>>()?;
+            if a.len() != b.len() {
+                return Err(PyValueError::new_err("length mismatch"));
+            }
+            let out = PyArray1::<f64>::zeros(py, a.len(), false);
+            let mut slice = unsafe { out.as_slice_mut().unwrap() };
+            slice.copy_from_slice(a.as_slice()?);
+            par_mul_inplace(&mut slice, b.as_slice()?);
+            Ok(out.into_py(py))
+        }
+        RustDtype::F32 => {
+            let a = a.downcast::<PyReadonlyArray1<f32>>()?;
+            let b = b.downcast::<PyReadonlyArray1<f32>>()?;
+            if a.len() != b.len() {
+                return Err(PyValueError::new_err("length mismatch"));
+            }
+            let out = PyArray1::<f32>::zeros(py, a.len(), false);
+            let mut slice = unsafe { out.as_slice_mut().unwrap() };
+            slice.copy_from_slice(a.as_slice()?);
+            par_mul_inplace_f32(&mut slice, b.as_slice()?);
+            Ok(out.into_py(py))
+        }
+    }
+}
+
+#[pyfunction]
+fn divide(a: &PyAny, b: &PyAny, py: Python) -> PyResult<PyObject> {
+    match *DTYPE.read().unwrap() {
+        RustDtype::F64 => {
+            let a = a.downcast::<PyReadonlyArray1<f64>>()?;
+            let b = b.downcast::<PyReadonlyArray1<f64>>()?;
+            if a.len() != b.len() {
+                return Err(PyValueError::new_err("length mismatch"));
+            }
+            let out = PyArray1::<f64>::zeros(py, a.len(), false);
+            let mut slice = unsafe { out.as_slice_mut().unwrap() };
+            slice.copy_from_slice(a.as_slice()?);
+            par_div_inplace(&mut slice, b.as_slice()?);
+            Ok(out.into_py(py))
+        }
+        RustDtype::F32 => {
+            let a = a.downcast::<PyReadonlyArray1<f32>>()?;
+            let b = b.downcast::<PyReadonlyArray1<f32>>()?;
+            if a.len() != b.len() {
+                return Err(PyValueError::new_err("length mismatch"));
+            }
+            let out = PyArray1::<f32>::zeros(py, a.len(), false);
+            let mut slice = unsafe { out.as_slice_mut().unwrap() };
+            slice.copy_from_slice(a.as_slice()?);
+            par_div_inplace_f32(&mut slice, b.as_slice()?);
+            Ok(out.into_py(py))
+        }
+    }
+}
+
+#[pyfunction(name = "map")]
+fn map_array(a: &PyAny, func: &PyAny, py: Python) -> PyResult<PyObject> {
+    match *DTYPE.read().unwrap() {
+        RustDtype::F64 => {
+            let a = a.downcast::<PyReadonlyArray1<f64>>()?;
+            let in_slice = a.as_slice()?;
+            let out = PyArray1::<f64>::zeros(py, a.len(), false);
+            let mut out_slice = unsafe { out.as_slice_mut().unwrap() };
+            for (o, &x) in out_slice.iter_mut().zip(in_slice.iter()) {
+                let val: f64 = func.call1((x,))?.extract()?;
+                *o = val;
+            }
+            Ok(out.into_py(py))
+        }
+        RustDtype::F32 => {
+            let a = a.downcast::<PyReadonlyArray1<f32>>()?;
+            let in_slice = a.as_slice()?;
+            let out = PyArray1::<f32>::zeros(py, a.len(), false);
+            let mut out_slice = unsafe { out.as_slice_mut().unwrap() };
+            for (o, &x) in out_slice.iter_mut().zip(in_slice.iter()) {
+                let val: f32 = func.call1((x,))?.extract()?;
+                *o = val;
+            }
+            Ok(out.into_py(py))
+        }
+    }
+}
+
+#[pyfunction]
+fn set_dtype(dtype: &str) -> PyResult<()> {
+    let mut dt = DTYPE.write().unwrap();
+    *dt = match dtype {
+        "f32" | "float32" => RustDtype::F32,
+        "f64" | "float64" => RustDtype::F64,
+        _ => return Err(PyValueError::new_err("unsupported dtype")),
+    };
+    Ok(())
+}
+
+#[pyfunction]
+fn get_dtype() -> PyResult<String> {
+    let dt = DTYPE.read().unwrap();
+    Ok(match *dt {
+        RustDtype::F32 => "f32",
+        RustDtype::F64 => "f64",
+    }
+    .to_string())
+}
+
+#[pyfunction]
+fn to_pandas(rb: &PyAny, py: Python) -> PyResult<PyObject> {
+    let pa = py.import("pyarrow")?;
+    let table = pa.call_method1("Table.from_batches", (vec![rb],))?;
+    let df = table.call_method0("to_pandas")?;
+    Ok(df.into())
+}
+
+#[pymodule]
+fn klongpy_rs(py: Python, m: &PyModule) -> PyResult<()> {
+    pyo3::prepare_freethreaded_python();
+    m.add_class::<PyArrayF64>()?;
+    m.add_function(wrap_pyfunction!(add, m)?)?;
+    m.add_function(wrap_pyfunction!(subtract, m)?)?;
+    m.add_function(wrap_pyfunction!(multiply, m)?)?;
+    m.add_function(wrap_pyfunction!(divide, m)?)?;
+    m.add_function(wrap_pyfunction!(map_array, m)?)?;
+    m.add_function(wrap_pyfunction!(set_dtype, m)?)?;
+    m.add_function(wrap_pyfunction!(get_dtype, m)?)?;
+    m.add_function(wrap_pyfunction!(to_pandas, m)?)?;
+    Ok(())
+}

--- a/klongpy/__init__.py
+++ b/klongpy/__init__.py
@@ -1,2 +1,19 @@
+try:
+    from klongpy_rs import *  # compiled fast-path
+except ImportError:
+    from .numpy_backend import *  # pure-Python fallback
+
 from .interpreter import KlongInterpreter, KlongException
-__all__ = ["KlongInterpreter", "KlongException"]
+__all__ = [
+    "KlongInterpreter",
+    "KlongException",
+    "add",
+    "subtract",
+    "multiply",
+    "divide",
+    "map",
+    "set_dtype",
+    "get_dtype",
+    "to_pandas",
+    "PyArrayF64",
+]

--- a/klongpy/backend.py
+++ b/klongpy/backend.py
@@ -101,3 +101,13 @@ else:
     np.isarray = lambda x: isinstance(x, np.ndarray)
 
 np
+
+try:
+    from klongpy_rs import add as rust_add, subtract as rust_subtract, \
+        multiply as rust_multiply, divide as rust_divide
+    np.add = rust_add
+    np.subtract = rust_subtract
+    np.multiply = rust_multiply
+    np.divide = rust_divide
+except Exception:
+    pass

--- a/klongpy/numpy_backend.py
+++ b/klongpy/numpy_backend.py
@@ -1,0 +1,22 @@
+from .backend import np
+
+def add(a, b):
+    return np.add(a, b)
+
+def subtract(a, b):
+    return np.subtract(a, b)
+
+def multiply(a, b):
+    return np.multiply(a, b)
+
+def divide(a, b):
+    return np.divide(a, b)
+
+def map(a, func):
+    return np.vectorize(func)(a)
+
+def set_dtype(dtype):
+    return None
+
+def get_dtype():
+    return "f64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["maturin>=1.5"]
+build-backend = "maturin"
+
+[project]
+name = "klongpy"
+version = "0.8.0a1"
+authors = ["YOUR NAME <you@example.com>"]
+dependencies = [
+    "numpy>=1.25",
+    "pandas>=3.0",
+    "duckdb>=0.10",
+    "pyarrow>=15.0"
+]
+optional-dependencies = { duckdb = ["duckdb>=0.10"] }
+
+[tool.maturin]
+bindings = "pyo3"
+features = ["duckdb"]

--- a/tests/test_arithmetic.py
+++ b/tests/test_arithmetic.py
@@ -1,0 +1,31 @@
+import unittest
+import numpy as np
+import klongpy as k
+
+class TestRustArithmetic(unittest.TestCase):
+    def test_add(self):
+        a = np.arange(16, dtype=np.float64)
+        b = np.ones_like(a)
+        out = k.add(a, b)
+        np.testing.assert_array_equal(out, a + b)
+
+    def test_subtract(self):
+        a = np.arange(16, dtype=np.float64)
+        b = np.ones_like(a)
+        out = k.subtract(a, b)
+        np.testing.assert_array_equal(out, a - b)
+
+    def test_multiply(self):
+        a = np.arange(16, dtype=np.float64)
+        b = np.ones_like(a) * 2
+        out = k.multiply(a, b)
+        np.testing.assert_array_equal(out, a * b)
+
+    def test_divide(self):
+        a = np.arange(1, 17, dtype=np.float64)
+        b = np.ones_like(a) * 2
+        out = k.divide(a, b)
+        np.testing.assert_array_equal(out, a / b)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_dtype.py
+++ b/tests/test_dtype.py
@@ -1,0 +1,16 @@
+import unittest
+import numpy as np
+import klongpy as k
+
+class TestRustDtype(unittest.TestCase):
+    def test_set_dtype_f32(self):
+        k.set_dtype('f32')
+        a = np.arange(16, dtype=np.float32)
+        b = np.ones_like(a)
+        out = k.add(a, b)
+        self.assertEqual(out.dtype, np.float32)
+        np.testing.assert_array_equal(out, a + b)
+        k.set_dtype('f64')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -1,0 +1,12 @@
+import unittest
+import numpy as np
+import klongpy as k
+
+class TestRustMap(unittest.TestCase):
+    def test_map_lambda(self):
+        a = np.arange(5, dtype=np.float64)
+        out = k.map(a, lambda x: x * 2)
+        np.testing.assert_array_equal(out, a * 2)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement map_inplace helpers for f64/f32 in the Rust core
- expose new `map` function in PyO3 bindings
- update Python shim and NumPy fallback
- test applying a Python lambda via `map`
- merge add test into arithmetic suite

## Testing
- `python3 -m unittest`


------
https://chatgpt.com/codex/tasks/task_e_6864050514dc833285ffac4a853cdac8