### PR TITLE
Implement modular backend with numpy & torch support

### DIFF
--- a/klongpy/backends/__init__.py
+++ b/klongpy/backends/__init__.py
@@ -1,0 +1,10 @@
+"""Backend implementations."""
+
+from . import numpy_backend
+
+try:
+    from . import torch_backend  # noqa: F401
+except Exception:  # torch may not be available
+    torch_backend = None
+
+__all__ = ["numpy_backend", "torch_backend"]

--- a/klongpy/backends/numpy_backend.py
+++ b/klongpy/backends/numpy_backend.py
@@ -1,0 +1,167 @@
+"""NumPy backend with minimal reverse-mode autodiff."""
+
+from __future__ import annotations
+
+import numpy as np
+from typing import Any, Callable, Iterable, Optional
+
+
+class Tensor:
+    """Simple tensor wrapper for reverse-mode autodiff."""
+
+    def __init__(self, data: np.ndarray, _children: Iterable[Tensor] = (), requires_grad: bool = False):
+        self.data = np.asarray(data)
+        if self.data.dtype == object:
+            raise TypeError("object dtype not supported")
+        self.requires_grad = requires_grad
+        self.grad: Optional[np.ndarray] = np.zeros_like(self.data, dtype=self.data.dtype) if requires_grad else None
+        self._prev = set(_children)
+        self._backward: Callable[[], None] = lambda: None
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f"Tensor(data={self.data}, grad={self.grad})"
+
+
+def array(obj: Any, *, dtype: Any | None = None, requires_grad: bool = False) -> Any:
+    """Create an array or tensor."""
+    if isinstance(obj, Tensor):
+        data = obj.data if dtype is None else obj.data.astype(dtype)
+        return Tensor(data, requires_grad=requires_grad or obj.requires_grad)
+    arr = np.asarray(obj, dtype=dtype)
+    if arr.dtype == object:
+        raise TypeError("object dtype not supported")
+    return Tensor(arr, requires_grad=requires_grad) if requires_grad else arr
+
+
+def _ensure_tensor(x: Any) -> Tensor:
+    if isinstance(x, Tensor):
+        return x
+    arr = np.asarray(x)
+    if arr.dtype == object:
+        raise TypeError("object dtype not supported")
+    return Tensor(arr)
+
+
+def _broadcast_grad(grad: np.ndarray, shape: tuple[int, ...]) -> np.ndarray:
+    g = grad
+    while len(g.shape) > len(shape):
+        g = g.sum(axis=0)
+    for i, dim in enumerate(shape):
+        if dim == 1:
+            g = g.sum(axis=i, keepdims=True)
+    return g
+
+
+def add(a: Any, b: Any) -> Any:
+    """Element-wise addition."""
+    if not isinstance(a, Tensor) and not isinstance(b, Tensor):
+        return np.add(a, b)
+    ta, tb = _ensure_tensor(a), _ensure_tensor(b)
+    out = Tensor(ta.data + tb.data, (ta, tb), requires_grad=ta.requires_grad or tb.requires_grad)
+
+    def _backward() -> None:
+        if out.grad is None:
+            return
+        if ta.requires_grad:
+            ta.grad += _broadcast_grad(out.grad, ta.data.shape)
+        if tb.requires_grad:
+            tb.grad += _broadcast_grad(out.grad, tb.data.shape)
+
+    out._backward = _backward
+    return out
+
+
+def mul(a: Any, b: Any) -> Any:
+    """Element-wise multiplication."""
+    if not isinstance(a, Tensor) and not isinstance(b, Tensor):
+        return np.multiply(a, b)
+    ta, tb = _ensure_tensor(a), _ensure_tensor(b)
+    out = Tensor(ta.data * tb.data, (ta, tb), requires_grad=ta.requires_grad or tb.requires_grad)
+
+    def _backward() -> None:
+        if out.grad is None:
+            return
+        if ta.requires_grad:
+            ta.grad += _broadcast_grad(out.grad * tb.data, ta.data.shape)
+        if tb.requires_grad:
+            tb.grad += _broadcast_grad(out.grad * ta.data, tb.data.shape)
+
+    out._backward = _backward
+    return out
+
+
+def matmul(a: Any, b: Any) -> Any:
+    """Matrix multiplication."""
+    if not isinstance(a, Tensor) and not isinstance(b, Tensor):
+        return np.matmul(a, b)
+    ta, tb = _ensure_tensor(a), _ensure_tensor(b)
+    out = Tensor(ta.data @ tb.data, (ta, tb), requires_grad=ta.requires_grad or tb.requires_grad)
+
+    def _backward() -> None:
+        if out.grad is None:
+            return
+        if ta.requires_grad:
+            ta.grad += out.grad @ tb.data.T
+        if tb.requires_grad:
+            tb.grad += ta.data.T @ out.grad
+
+    out._backward = _backward
+    return out
+
+
+def sum(a: Any, axis: int | None = None) -> Any:
+    """Sum of elements."""
+    if not isinstance(a, Tensor):
+        return np.sum(a, axis=axis)
+    out = Tensor(np.sum(a.data, axis=axis), (a,), requires_grad=a.requires_grad)
+
+    def _backward() -> None:
+        if out.grad is None or not a.requires_grad:
+            return
+        grad = out.grad
+        if axis is None:
+            grad = np.broadcast_to(grad, a.data.shape)
+        else:
+            grad = np.expand_dims(grad, axis)
+            grad = np.broadcast_to(grad, a.data.shape)
+        a.grad += grad
+
+    out._backward = _backward
+    return out
+
+
+def stop(x: Any) -> Any:
+    """Detach ``x`` from the autograd graph."""
+    if isinstance(x, Tensor):
+        return Tensor(x.data.copy(), requires_grad=False)
+    return x
+
+
+def grad(fn: Callable[..., Any], wrt: int = 0) -> Callable[..., Any]:
+    """Return a function computing ``∂fn/∂arg[wrt]``."""
+
+    def _grad_fn(*args: Any) -> Any:
+        targs = []
+        for i, a in enumerate(args):
+            t = array(a, requires_grad=(i == wrt))
+            targs.append(t)
+        out = fn(*targs)
+        if not isinstance(out, Tensor):
+            raise RuntimeError("not differentiable")
+        out.grad = np.ones_like(out.data)
+        topo: list[Tensor] = []
+        visited: set[Tensor] = set()
+
+        def build(v: Tensor) -> None:
+            if v not in visited:
+                visited.add(v)
+                for child in v._prev:
+                    build(child)
+                topo.append(v)
+
+        build(out)
+        for node in reversed(topo):
+            node._backward()
+        return targs[wrt].grad
+
+    return _grad_fn

--- a/klongpy/backends/torch_backend.py
+++ b/klongpy/backends/torch_backend.py
@@ -1,0 +1,95 @@
+"""Torch backend using NumPy fallback for strings."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+from importlib import import_module
+
+try:
+    import torch
+except Exception as e:  # pragma: no cover - optional dependency
+    raise ImportError("torch backend requires the 'torch' package") from e
+
+import numpy as np
+from . import numpy_backend as npb
+
+
+def _contains_strings(x: Any) -> bool:
+    if isinstance(x, str):
+        return True
+    if isinstance(x, (list, tuple)):
+        return any(_contains_strings(i) for i in x)
+    if isinstance(x, np.ndarray):
+        return x.dtype.kind in {"U", "S", "O"}
+    return False
+
+
+def _to_numpy(x: Any) -> Any:
+    if isinstance(x, torch.Tensor):
+        return x.detach().cpu().numpy()
+    return x
+
+
+def array(obj: Any, *, dtype: Any | None = None, requires_grad: bool = False) -> Any:
+    """Create a torch tensor or numpy array."""
+    if _contains_strings(obj):
+        return npb.array(obj, dtype=dtype, requires_grad=requires_grad)
+    return torch.tensor(obj, dtype=dtype, requires_grad=requires_grad)
+
+
+def _torchify(x: Any) -> torch.Tensor:
+    if isinstance(x, torch.Tensor):
+        return x
+    return torch.tensor(x)
+
+
+def add(a: Any, b: Any) -> Any:
+    if _contains_strings(a) or _contains_strings(b):
+        return npb.add(_to_numpy(a), _to_numpy(b))
+    return _torchify(a) + _torchify(b)
+
+
+def mul(a: Any, b: Any) -> Any:
+    if _contains_strings(a) or _contains_strings(b):
+        return npb.mul(_to_numpy(a), _to_numpy(b))
+    return _torchify(a) * _torchify(b)
+
+
+def matmul(a: Any, b: Any) -> Any:
+    if _contains_strings(a) or _contains_strings(b):
+        return npb.matmul(_to_numpy(a), _to_numpy(b))
+    return _torchify(a) @ _torchify(b)
+
+
+def sum(a: Any, axis: int | None = None) -> Any:
+    if _contains_strings(a):
+        return npb.sum(_to_numpy(a), axis=axis)
+    return torch.sum(_torchify(a), dim=axis)
+
+
+def stop(x: Any) -> Any:
+    if isinstance(x, torch.Tensor):
+        return x.detach()
+    return npb.stop(x)
+
+
+def grad(fn: Callable[..., Any], wrt: int = 0) -> Callable[..., Any]:
+    """Return a function computing ``∂fn/∂arg[wrt]`` using torch.autograd."""
+
+    def _grad_fn(*args: Any) -> Any:
+        if any(_contains_strings(a) for a in args):
+            raise RuntimeError("not differentiable")
+        targs = []
+        for i, a in enumerate(args):
+            if isinstance(a, torch.Tensor):
+                t = a.clone().detach().requires_grad_(i == wrt)
+            else:
+                t = torch.tensor(a, dtype=torch.float64, requires_grad=(i == wrt))
+            targs.append(t)
+        out = fn(*targs)
+        if not isinstance(out, torch.Tensor):
+            raise RuntimeError("not differentiable")
+        g, = torch.autograd.grad(out, targs[wrt])
+        return g
+
+    return _grad_fn

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,0 +1,47 @@
+import unittest
+import numpy as np
+
+from klongpy import backend
+
+
+class TestBackend(unittest.TestCase):
+    def _check_grad(self, name: str):
+        try:
+            backend.set_backend(name)
+        except ImportError:
+            raise unittest.SkipTest(f"{name} backend not available")
+        b = backend.current()
+
+        def f(x):
+            return b.sum(b.mul(b.add(x, 1), b.add(x, 1)))
+
+        g = b.grad(f)
+        x = b.array([1.0, 2.0, 3.0], requires_grad=True)
+        grad = g(x)
+        if hasattr(grad, "detach"):
+            grad = grad.detach().cpu().numpy()
+        np.testing.assert_allclose(np.array(grad), np.array([4.0, 6.0, 8.0]))
+
+    def test_grad_numpy(self):
+        self._check_grad("numpy")
+
+    def test_grad_torch(self):
+        self._check_grad("torch")
+
+    def test_strings_not_differentiable(self):
+        try:
+            backend.set_backend("torch")
+        except ImportError:
+            raise unittest.SkipTest("torch backend not available")
+        b = backend.current()
+
+        def f(x):
+            return b.add(x, ["a", "b", "c"])
+
+        x = b.array([1.0, 2.0, 3.0], requires_grad=True)
+        with self.assertRaisesRegex(RuntimeError, "not differentiable"):
+            b.grad(f)(x)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- introduce backend switcher with `current()` and `set_backend()`
- add NumPy backend featuring tiny autodiff engine
- add Torch backend with NumPy fallback for strings
- expose backends package and maintain legacy `np` shim
- add tests for backend switching and gradient computation
- provide top-level wrappers to backend ops via `backend` module

## Testing
- `python3 -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_686dcd5cad308332b40134deecfbe87f