### PR TITLE
Fix unused numpy import lint error

### DIFF
--- a/klongpy/backends/torch_backend.py
+++ b/klongpy/backends/torch_backend.py
@@ -9,7 +9,6 @@ try:
 except Exception as e:  # pragma: no cover - optional dependency
     raise ImportError("torch backend requires the 'torch' package") from e
 
-import numpy as np
 from . import numpy_backend as npb
 
 def _to_numpy(x: Any) -> Any:


### PR DESCRIPTION
## Summary
- remove unused `numpy` import in torch backend

## Testing
- `python3 -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_686f0954453c8332bb4253ceccc24722