### PR TITLE
Fix timer callback to dynamically lookup function

### DIFF
--- a/docs/timer.md
+++ b/docs/timer.md
@@ -7,6 +7,10 @@ cb::{.p("hello")}
 th::.timer("greeting";1;cb)
 ```
 
+Timers look up the callback function each time they execute. Updating the
+function definition after creating the timer will change the behavior on the
+next tick.
+
 To stop the timer, it can be closed via:
 
 ```

--- a/tests/test_sys_fn_timer.py
+++ b/tests/test_sys_fn_timer.py
@@ -131,3 +131,27 @@ class TestSysFnTimer(LoopsBase, unittest.TestCase):
         task = self.klongloop.call_soon_threadsafe(asyncio.create_task, _test())
         asyncio.run_coroutine_threadsafe(_test_result(), self.klongloop).result()
         task.cancel()
+
+    def test_timer_dynamic_lookup(self):
+        klong = KlongInterpreter()
+        klong['.system'] = {'ioloop': self.ioloop, 'klongloop': self.klongloop}
+
+        async def _test():
+            klong('result::""')
+            klong('cb::{result::"h1";1}')
+            klong('th::.timer("test";0;cb)')
+            while klong('result') != 'h1':
+                await asyncio.sleep(0)
+            klong('cb::{result::"h2";0}')
+
+        async def _test_result():
+            r = klong('result')
+            while r != 'h2':
+                await asyncio.sleep(0)
+                r = klong('result')
+            r = klong('.timerc(th)')
+            self.assertEqual(r,0)
+
+        task = self.klongloop.call_soon_threadsafe(asyncio.create_task, _test())
+        asyncio.run_coroutine_threadsafe(_test_result(), self.klongloop).result()
+        task.cancel()


### PR DESCRIPTION
## Summary
- make timer callback look up the function symbol each tick
- mention dynamic lookup in timer docs
- add a regression test for redefining timer functions

## Testing
- `python3 -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_6871a2a752d48332858e4c2e87522805