### PR TITLE
Fix file handle leak in test_simple_cat

### DIFF
--- a/tests/test_sys_fn.py
+++ b/tests/test_sys_fn.py
@@ -401,7 +401,7 @@ class TestSysFn(unittest.TestCase):
     def test_simple_cat(self):
         t = """
         cat::{.mi{.p(x);.rl()}:~.rl()}
-        type::{.fc(.ic(x));cat()}
+        type::{[ic];ic::.ic(x);.fc(ic);cat();.cc(ic)}
         copy::{[of];.tc(of::.oc(y));type(x);.cc(of)}
         """
         klong = KlongInterpreter()


### PR DESCRIPTION
## Summary
- close temp file opened by `.ic` in the `type` helper to avoid leaking the file handle
- update simple_cat test script accordingly

## Testing
- `python3 -m unittest tests.test_sys_fn.TestSysFn.test_simple_cat -v`
- `python3 -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_6871a2c441408332b5d7be7f2f658baf