### PR TITLE
Fix timer callback to dynamically lookup function

### DIFF
--- a/docs/timer.md
+++ b/docs/timer.md
@@ -7,6 +7,13 @@ cb::{.p("hello")}
 th::.timer("greeting";1;cb)
 ```
 
+Timers look up the callback function each time they execute. Updating the
+function definition after creating the timer will change the behavior on the
+next tick.
+
+Intervals may be fractional to allow sub-second timers, e.g. `.timer("g";0.5;cb)`
+fires every half-second.
+
 To stop the timer, it can be closed via:
 
 ```

--- a/klongpy/sys_fn_timer.py
+++ b/klongpy/sys_fn_timer.py
@@ -1,7 +1,7 @@
 import asyncio
 import sys
 
-from klongpy.core import KGCall, KGFn, KGFnWrapper
+from klongpy.core import KGSym, KGCall, KGFn, KGFnWrapper
 
 
 class KGTimerHandler:
@@ -73,15 +73,40 @@ def eval_sys_fn_timer(klong, x, y, z):
             th::.timer("count";1;cb)
 
     """
-    y= int(y)
+    try:
+        y = float(y)
+    except Exception:
+        return "y must be a non-negative number"
     if y < 0:
-        return "x must be a non-negative integer"
-    z = z if isinstance(z, KGCall) else KGFnWrapper(klong, z) if isinstance(z, KGFn) else z
-    if not callable(z):
-        return "z must be a function"
+        return "y must be a non-negative number"
+
+    sym = None
+    if isinstance(z, (KGFn, KGCall)):
+        for ctx in reversed(klong._context._context):
+            for k, v in ctx.items():
+                if v is z and k not in (KGSym('x'), KGSym('y'), KGSym('z')):
+                    sym = k
+                    break
+            if sym is not None:
+                break
+    elif isinstance(z, KGSym):
+        sym = z
+
+    if sym is not None:
+        def callback():
+            fn = klong[sym]
+            fn = fn if isinstance(fn, KGCall) else KGFnWrapper(klong, fn) if isinstance(fn, KGFn) else fn
+            if not callable(fn):
+                raise RuntimeError("z must be a function")
+            return fn()
+    else:
+        callback = z if isinstance(z, KGCall) else KGFnWrapper(klong, z) if isinstance(z, KGFn) else z
+        if not callable(callback):
+            return "z must be a function"
+
     system = klong['.system']
     klongloop = system['klongloop']
-    return _call_periodic(klongloop, x, y, z)
+    return _call_periodic(klongloop, x, y, callback)
 
 
 def eval_sys_fn_cancel_timer(x):

--- a/tests/test_sys_fn_timer.py
+++ b/tests/test_sys_fn_timer.py
@@ -54,6 +54,32 @@ class TestSysFnTimer(LoopsBase, unittest.TestCase):
         asyncio.run_coroutine_threadsafe(_test_result(), self.klongloop).result()
         task.cancel()
 
+    def test_timer_fractional_interval(self):
+        klong = KlongInterpreter()
+        klong['.system'] = {'ioloop': self.ioloop, 'klongloop': self.klongloop}
+
+        start_t = self.klongloop.time()
+
+        async def _test():
+            klong("result::0")
+            klong('cb::{result::result+1;result<2}')
+            klong('th::.timer("test";0.1;cb)')
+
+        async def _test_result():
+            r = klong("result")
+            self.assertTrue(r >= 0 and r < 3)
+            while r != 2:
+                await asyncio.sleep(0)
+                r = klong("result")
+            delta_t = (self.klongloop.time() - start_t)
+            self.assertTrue(delta_t >= 0.2)
+            r = klong(".timerc(th)")
+            self.assertEqual(r,0)
+
+        task = self.klongloop.call_soon_threadsafe(asyncio.create_task, _test())
+        asyncio.run_coroutine_threadsafe(_test_result(), self.klongloop).result()
+        task.cancel()
+
     def test_timer_return_1_cancel(self):
         klong = KlongInterpreter()
         klong['.system'] = {'ioloop': self.ioloop, 'klongloop': self.klongloop}
@@ -126,6 +152,30 @@ class TestSysFnTimer(LoopsBase, unittest.TestCase):
             r = klong(".timerc(th)")
             self.assertEqual(r,1)
             r = klong(".timerc(th)")
+            self.assertEqual(r,0)
+
+        task = self.klongloop.call_soon_threadsafe(asyncio.create_task, _test())
+        asyncio.run_coroutine_threadsafe(_test_result(), self.klongloop).result()
+        task.cancel()
+
+    def test_timer_dynamic_lookup(self):
+        klong = KlongInterpreter()
+        klong['.system'] = {'ioloop': self.ioloop, 'klongloop': self.klongloop}
+
+        async def _test():
+            klong('result::""')
+            klong('cb::{result::"h1";1}')
+            klong('th::.timer("test";0;cb)')
+            while klong('result') != 'h1':
+                await asyncio.sleep(0)
+            klong('cb::{result::"h2";0}')
+
+        async def _test_result():
+            r = klong('result')
+            while r != 'h2':
+                await asyncio.sleep(0)
+                r = klong('result')
+            r = klong('.timerc(th)')
             self.assertEqual(r,0)
 
         task = self.klongloop.call_soon_threadsafe(asyncio.create_task, _test())


### PR DESCRIPTION
## Summary
- make timer callback look up the function symbol each tick
- allow fractional timer intervals
- mention dynamic lookup and fractional intervals in timer docs
- add regression tests for redefining timer functions and fractional intervals

## Testing
- `python3 -m unittest`


------
https://chatgpt.com/codex/tasks/task_e_6871a2a752d48332858e4c2e87522805